### PR TITLE
feat(serve): remote gateway URL mode improvements — retry, short-circuit, server-side filtering, multi-worker

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,71 @@
+## Overview
+
+This PR improves the remote gateway URL mode (`ml_gateway_mode: url`) with several enhancements that make it production-ready for real-world deployments. All changes are **strictly scoped to the URL gateway path** (`detect_event` → `_remote_detect_urls` → `pyzm.serve`). The local mode and the image gateway mode (`ml_gateway_mode: image`) are completely unaffected.
+
+## Changes
+
+### 1. Frame selection with `start_frame` / `frame_skip` / `max_frames`
+
+In URL gateway mode, the client builds a list of frame URLs and sends them to the gateway. Previously, when `frame_set` was empty the client fell back to a hardcoded `["snapshot"]` — a single frame.
+
+This PR introduces a three-way selection strategy:
+
+1. **`frame_set` has values** — use them as-is (existing behaviour, unchanged)
+2. **`frame_set` is empty AND `max_frames > 0`** — use `start_frame` + `frame_skip` + `max_frames` to build a sparse frame list distributed across the event.
+   Example: `start_frame=50, frame_skip=25, max_frames=30` generates `[50, 75, 100, ..., 775]`.
+   This is more effective than snapshots for detecting objects that appear briefly.
+3. **`frame_set` is empty AND `max_frames` is 0 (not set)** — fall back to the default `["snapshot", "alarm", "1"]` with a warning, avoiding silent single-frame analysis.
+
+Existing installations that do not explicitly set `frame_set: []` are completely unaffected.
+
+### 2. Retry for missing frames (live events)
+
+In live events frames are still being written to disk when detection starts. The gateway now retries missing frames (HTTP 404) up to `max_attempts` times, sleeping `sleep_between_attempts` seconds between attempts. After exhausting retries, consecutive 404s are counted and processing stops after `contig_frames_before_error` consecutive misses.
+
+New `StreamConfig` fields forwarded to the gateway:
+- `max_attempts` (default: 1)
+- `sleep_between_attempts` (default: 3)
+- `contig_frames_before_error` (default: 5)
+
+### 3. Server-side filtering (confidence, pattern, zones) and short-circuit
+
+Previously the gateway returned all raw detections and the client applied all filters. This meant the gateway always processed every frame, even when an early frame already had a clear match in zone.
+
+The gateway now applies filters in order before the short-circuit check:
+
+1. **Confidence filter** — drops detections below `min_confidence` (derived from the lowest `min_confidence` across enabled models)
+2. **Pattern filter** — drops labels not matching the client pattern (e.g. `"(person)"`)
+3. **Zone filter** — checks whether surviving detections intersect the zone polygons forwarded by the client
+4. **Short-circuit** — when `stop_on_match=True` (default), stops processing as soon as a frame passes all filters, avoiding unnecessary inference on remaining frames
+
+New `StreamConfig` field: `stop_on_match: bool = True`
+
+### 4. Multi-worker support for `pyzm.serve` (CPU)
+
+Added `--workers N` CLI argument to `pyzm.serve`. This is primarily useful when running on **CPU**, where each YOLOv4 inference call is blocking and takes ~500ms per frame. With a single worker, simultaneous events queue up and wait. With multiple workers, each event is handled by an independent process with its own model copy in memory, enabling truly parallel inference.
+
+**Note:** On GPU the inference is fast enough that a single worker is generally sufficient. Multi-worker is not recommended on GPU as it multiplies VRAM usage without meaningful throughput gain.
+
+Each worker loads the model independently (~443MB per worker for YOLOv4 at 576×576). The server configuration is serialised to the `PYZM_SERVER_CONFIG` environment variable so each worker can reconstruct it via `get_app()` without re-parsing CLI arguments.
+
+New `ServerConfig` fields:
+- `workers: int = 1`
+- `log_level: str = "info"`
+
+## Files changed
+
+| File | Scope |
+|------|-------|
+| `pyzm/ml/detector.py` | URL gateway path only |
+| `pyzm/serve/app.py` | Gateway server only |
+| `pyzm/serve/__main__.py` | Gateway server only |
+| `pyzm/models/config.py` | New fields, backwards compatible |
+
+## Testing
+
+Tested in production on nvr-raimon (Debian 13, Python 3.13, ~34 cameras) with:
+- YOLOv4 custom trained model (2 classes: person/dog)
+- 3 workers running in parallel
+- Live event detection with retry
+- Short-circuit confirmed stopping at first in-zone match
+- Pattern filter confirmed suppressing non-person detections

--- a/pyzm/ml/detector.py
+++ b/pyzm/ml/detector.py
@@ -391,10 +391,10 @@ class Detector:
         zones: list["Zone"] | None = None,
         verify_ssl: bool = True,
         original_shape: tuple[int, int] | None = None,
-        contig_frames_before_error: int = 3,
-        stop_on_match: bool = False,
+        contig_frames_before_error: int = 5,
+        stop_on_match: bool = True,
         max_attempts: int = 1,
-        sleep_between_attempts: int = 2,
+        sleep_between_attempts: int = 3,
         min_confidence: float = 0.3,
         pattern: str = ".*",
     ) -> DetectionResult:

--- a/pyzm/ml/detector.py
+++ b/pyzm/ml/detector.py
@@ -391,8 +391,38 @@ class Detector:
         zones: list["Zone"] | None = None,
         verify_ssl: bool = True,
         original_shape: tuple[int, int] | None = None,
+        contig_frames_before_error: int = 3,
+        stop_on_match: bool = False,
+        max_attempts: int = 1,
+        sleep_between_attempts: int = 2,
+        min_confidence: float = 0.3,
+        pattern: str = ".*",
     ) -> DetectionResult:
-        """Send frame URLs to the remote gateway, apply client-side filtering."""
+        """Send frame URLs to the remote gateway, apply client-side filtering.
+
+        Parameters
+        ----------
+        contig_frames_before_error:
+            Number of consecutive HTTP 404 responses before the gateway stops
+            processing (maps to stream_sequence.contig_frames_before_error).
+        stop_on_match:
+            When True the gateway stops as soon as one frame produces a
+            detection that passes all server-side filters (confidence, pattern
+            and zone).  Mirrors stream_sequence.stop_on_match.
+        max_attempts:
+            How many times the gateway retries a 404 frame before skipping it.
+            Useful for live events where frames are still being written.
+        sleep_between_attempts:
+            Seconds to wait between retry attempts for a missing frame.
+        min_confidence:
+            Minimum detection confidence forwarded to the gateway for
+            server-side filtering.  Derived from the lowest min_confidence
+            across all enabled models in the pipeline.
+        pattern:
+            Label-match regex forwarded to the gateway (e.g. "(person)").
+            Derived from the shared pattern across enabled models; falls back
+            to ".*" when models have different patterns.
+        """
         headers: dict[str, str] = {}
         token = self._ensure_gateway_token()
         if token:
@@ -402,6 +432,16 @@ class Detector:
             "urls": frame_urls,
             "zm_auth": zm_auth,
             "verify_ssl": verify_ssl,
+            # Gateway-side behaviour controls
+            "stop_on_match": stop_on_match,
+            "contig_frames_before_error": contig_frames_before_error,
+            "max_attempts": max_attempts,
+            "sleep_between_attempts": sleep_between_attempts,
+            # Server-side filters (applied before stop_on_match check)
+            "min_confidence": min_confidence,
+            "pattern": pattern,
+            # Zone polygons for server-side filtering and short-circuit
+            "zones": [z.as_dict() for z in zones] if zones else [],
         }
 
         resp = requests.post(
@@ -586,12 +626,49 @@ class Detector:
             auth_str = api.auth.get_auth_string()
             verify_ssl = api.config.verify_ssl
 
-            frame_ids = sc.frame_set if sc.frame_set else ["snapshot"]
+            if sc.frame_set:
+                # Explicit frame_set: use the provided list as-is.
+                # Supports named frames ("snapshot", "alarm") and numeric IDs.
+                frame_ids = sc.frame_set
+            elif sc.max_frames:
+                # Empty frame_set with max_frames configured: use the
+                # start_frame / frame_skip / max_frames sparse-sampling strategy.
+                # This is useful in URL gateway mode to distribute analysis
+                # evenly across a long event without downloading every frame.
+                # Example: start_frame=50, frame_skip=25, max_frames=30
+                #   → frames [50, 75, 100, ..., 775]
+                start = sc.start_frame or 1
+                skip = sc.frame_skip or 1
+                frame_ids = [str(start + i * skip) for i in range(sc.max_frames)]
+            else:
+                # frame_set is empty and max_frames is not configured (0).
+                # The caller has not explicitly chosen a frame-selection strategy,
+                # so fall back to the default behaviour to avoid silently
+                # analysing only a single frame.
+                logger.warning(
+                    "frame_set is empty but max_frames is not configured; "
+                    "falling back to default frame_set ['snapshot', 'alarm', '1']. "
+                    "To use sparse sampling, set max_frames (and optionally "
+                    "start_frame and frame_skip) in stream_sequence."
+                )
+                frame_ids = ["snapshot", "alarm", "1"]
             frame_urls = [
                 {"frame_id": str(fid), "url": f"{portal_url}/index.php?view=image&eid={event_id}&fid={fid}"}
                 for fid in frame_ids
             ]
-            return self._remote_detect_urls(frame_urls, auth_str, zones, verify_ssl)
+            # Extract per-model settings to forward to the gateway
+            min_conf = min((mc.min_confidence for mc in self._config.models if mc.enabled), default=0.3)
+            patterns = list({mc.pattern for mc in self._config.models if mc.enabled and mc.pattern})
+            pattern = patterns[0] if len(patterns) == 1 else ".*"
+            return self._remote_detect_urls(
+                frame_urls, auth_str, zones, verify_ssl,
+                contig_frames_before_error=sc.contig_frames_before_error,
+                stop_on_match=sc.stop_on_match,
+                max_attempts=sc.max_attempts,
+                sleep_between_attempts=sc.sleep_between_attempts,
+                min_confidence=min_conf,
+                pattern=pattern,
+            )
 
         # Get Event object and extract frames via OOP API
         ev = zm_client.event(event_id)

--- a/pyzm/models/config.py
+++ b/pyzm/models/config.py
@@ -547,7 +547,7 @@ class ServerConfig(BaseModel):
         default="info",
         description=(
             "Logging level propagated to each worker process. "
-            "Accepted values: debug, info, warning, error. "
+            "Any standard Python logging level name (debug, info, warning, error, critical). "
             "When --debug is passed on the CLI this is overridden to debug automatically."
         ),
     )

--- a/pyzm/models/config.py
+++ b/pyzm/models/config.py
@@ -448,6 +448,16 @@ class StreamConfig(BaseModel):
     save_frames_dir: str = "/tmp"
     delete_after_analyze: bool = False
     convert_snapshot_to_fid: bool = False
+    stop_on_match: bool = Field(
+        default=True,
+        description=(
+            "When True and operating in remote-gateway URL mode, the gateway stops "
+            "processing frames as soon as it finds a detection that passes all "
+            "server-side filters (confidence, pattern and zone). Set to False to "
+            "process all frames regardless of early matches. "
+            "Only relevant when ml_gateway and ml_gateway_mode=url are set."
+        ),
+    )
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "StreamConfig":
@@ -492,7 +502,7 @@ class StreamConfig(BaseModel):
 
         # Simple bool fields
         for key in (
-            "download", "disable_ssl_cert_check", "save_frames",
+            "download", "disable_ssl_cert_check", "save_frames", "stop_on_match",
             "delete_after_analyze", "convert_snapshot_to_fid",
         ):
             if key in d:
@@ -523,6 +533,24 @@ class ServerConfig(BaseModel):
     auth_password: SecretStr = SecretStr("")
     token_expiry_seconds: int = 3600
     token_secret: str = "change-me"
+    workers: int = Field(
+        default=1,
+        description=(
+            "Number of uvicorn worker processes to spawn. Each worker loads "
+            "the model independently into memory, enabling truly parallel "
+            "inference across simultaneous events. Requires the "
+            "pyzm.serve.app:get_app factory entry point (used automatically "
+            "when workers > 1)."
+        ),
+    )
+    log_level: str = Field(
+        default="info",
+        description=(
+            "Logging level propagated to each worker process. "
+            "Accepted values: debug, info, warning, error. "
+            "When --debug is passed on the CLI this is overridden to debug automatically."
+        ),
+    )
 
     @model_validator(mode="after")
     def _validate_models_all(self) -> "ServerConfig":

--- a/pyzm/serve/__main__.py
+++ b/pyzm/serve/__main__.py
@@ -31,6 +31,16 @@ def main() -> None:
     ap.add_argument("--token-secret", default="change-me")
     ap.add_argument("--debug", action="store_true", help="Enable debug logging")
     ap.add_argument(
+        "--workers",
+        type=int,
+        default=1,
+        help=(
+            "Number of uvicorn worker processes to spawn. Each worker loads "
+            "the model independently, enabling parallel inference across "
+            "simultaneous events. Requires Python 3.8+ and is ignored on Windows."
+        ),
+    )
+    ap.add_argument(
         "--config",
         help="Path to a YAML config file (ServerConfig). Overrides CLI flags.",
     )
@@ -61,20 +71,33 @@ def main() -> None:
             auth_username=args.auth_user,
             auth_password=args.auth_password,
             token_secret=args.token_secret,
+            workers=args.workers,
+            log_level="debug" if args.debug else "info",
         )
 
     from pyzm.serve.app import create_app
 
-    app = create_app(config)
-
-    import uvicorn
-
-    uvicorn.run(
-        app,
-        host=config.host,
-        port=config.port,
-        log_level="debug" if args.debug else "info",
-    )
+    import uvicorn, os
+    if config.workers > 1:
+        # Serialize config to env var so each worker process can reconstruct
+        # it via get_app() without re-parsing CLI arguments.
+        os.environ["PYZM_SERVER_CONFIG"] = config.model_dump_json()
+        uvicorn.run(
+            "pyzm.serve.app:get_app",
+            host=config.host,
+            port=config.port,
+            log_level="debug" if args.debug else "info",
+            workers=config.workers,
+            factory=True,
+        )
+    else:
+        app = create_app(config)
+        uvicorn.run(
+            app,
+            host=config.host,
+            port=config.port,
+            log_level="debug" if args.debug else "info",
+        )
 
 
 if __name__ == "__main__":

--- a/pyzm/serve/__main__.py
+++ b/pyzm/serve/__main__.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import argparse
+import os
 import sys
+import uvicorn
 
 
 def main() -> None:
@@ -77,7 +79,6 @@ def main() -> None:
 
     from pyzm.serve.app import create_app
 
-    import uvicorn, os
     if config.workers > 1:
         # Serialize config to env var so each worker process can reconstruct
         # it via get_app() without re-parsing CLI arguments.

--- a/pyzm/serve/app.py
+++ b/pyzm/serve/app.py
@@ -1,7 +1,7 @@
 """FastAPI application factory for the pyzm ML detection server."""
 
 from __future__ import annotations
-
+import asyncio
 import logging
 from contextlib import asynccontextmanager
 from typing import Any
@@ -31,7 +31,7 @@ def get_app() -> FastAPI:
     import json, logging, os
     raw = os.environ.get("PYZM_SERVER_CONFIG")
     config = ServerConfig.model_validate(json.loads(raw)) if raw else ServerConfig()
-    level = logging.DEBUG if config.log_level == "debug" else logging.INFO
+    level = getattr(logging, config.log_level.upper(), logging.INFO)
     logging.basicConfig(level=level, format="%(asctime)s %(name)s %(levelname)s %(message)s")
     logging.getLogger("pyzm").setLevel(level)
     return create_app(config)
@@ -162,9 +162,8 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
                     fetched = False
                     for attempt in range(1, max_attempts + 1):
                         if attempt > 1:
-                            import time
                             logger.info("Frame %s: does not exist yet, retrying in %ds (attempt %d/%d)", fid, sleep_secs, attempt, max_attempts)
-                            time.sleep(sleep_secs)
+                            await asyncio.sleep(sleep_secs)
                             resp2 = http_requests.get(url, timeout=10, verify=verify_ssl)
                             if resp2.status_code != 404:
                                 resp = resp2
@@ -215,11 +214,12 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
             data.pop("image", None)
             data["frame_id"] = fid
 
-            # 3. Zone filter + short-circuit: check whether any surviving
-            #    detection falls inside the requested zone polygons.
-            #    When stop_on_match is True (default) we stop as soon as we
-            #    find a frame with an in-zone detection, avoiding unnecessary
-            #    inference on the remaining frames.
+            # 3. Zone short-circuit: check whether any surviving detection
+            #    falls inside the requested zone polygons.
+            #    NOTE: we do NOT reassign result.detections here — all detections
+            #    (in-zone and out-of-zone) are returned to the client so it can
+            #    apply its own zone filtering and log what was discarded.
+            #    The zone check here is only used to drive stop_on_match.
             zones_data = payload.get("zones", [])
             has_zone_match = True
             if zones_data and result.detections:

--- a/pyzm/serve/app.py
+++ b/pyzm/serve/app.py
@@ -16,6 +16,27 @@ from pyzm.serve.auth import create_login_route, create_token_dependency
 logger = logging.getLogger("pyzm.serve")
 
 
+def get_app() -> FastAPI:
+    """Factory entry point for uvicorn multi-worker mode.
+
+    Reads the server configuration from the PYZM_SERVER_CONFIG environment
+    variable (JSON-serialised ServerConfig) so that each worker
+    process spawned by uvicorn receives the same configuration as the parent
+    without having to re-parse CLI arguments.  Falls back to a default
+    ServerConfig when the variable is absent (single-worker mode).
+
+    Logging is configured here so that each worker inherits the correct level
+    independently of the parent process.
+    """
+    import json, logging, os
+    raw = os.environ.get("PYZM_SERVER_CONFIG")
+    config = ServerConfig.model_validate(json.loads(raw)) if raw else ServerConfig()
+    level = logging.DEBUG if config.log_level == "debug" else logging.INFO
+    logging.basicConfig(level=level, format="%(asctime)s %(name)s %(levelname)s %(message)s")
+    logging.getLogger("pyzm").setLevel(level)
+    return create_app(config)
+
+
 def create_app(config: ServerConfig | None = None) -> FastAPI:
     """Build and return a configured FastAPI application.
 
@@ -117,6 +138,9 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
 
         detector: Detector = app.state.detector
         results = []
+        # Track consecutive 404s to detect end-of-event early
+        consecutive_404 = 0
+        max_consecutive_404 = payload.get("contig_frames_before_error", 3)
 
         for entry in urls:
             fid = str(entry.get("frame_id", ""))
@@ -130,6 +154,31 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
 
             try:
                 resp = http_requests.get(url, timeout=10, verify=verify_ssl)
+                if resp.status_code == 404:
+                    # Frame may not exist yet (live event still being written).
+                    # Retry up to max_attempts times before counting as missing.
+                    max_attempts = payload.get("max_attempts", 1)
+                    sleep_secs = payload.get("sleep_between_attempts", 2)
+                    fetched = False
+                    for attempt in range(1, max_attempts + 1):
+                        if attempt > 1:
+                            import time
+                            logger.info("Frame %s: does not exist yet, retrying in %ds (attempt %d/%d)", fid, sleep_secs, attempt, max_attempts)
+                            time.sleep(sleep_secs)
+                            resp2 = http_requests.get(url, timeout=10, verify=verify_ssl)
+                            if resp2.status_code != 404:
+                                resp = resp2
+                                fetched = True
+                                break
+                    if not fetched:
+                        consecutive_404 += 1
+                        logger.info("Frame %s: does not exist yet, skipping (%d consecutive)", fid, consecutive_404)
+                        if consecutive_404 >= max_consecutive_404:
+                            logger.info("Stopping after %d consecutive missing frames", consecutive_404)
+                            break
+                        continue
+                consecutive_404 = 0
+                logger.info("Frame %s: fetched OK, running inference", fid)
                 resp.raise_for_status()
                 arr = np.frombuffer(resp.content, dtype=np.uint8)
                 image = cv2.imdecode(arr, cv2.IMREAD_COLOR)
@@ -141,10 +190,47 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
                 continue
 
             result = detector.detect(image)
+
+            # --- Server-side filters ---
+            # 1. Confidence filter: drop detections below the threshold
+            #    forwarded by the client (derived from model min_confidence).
+            min_confidence = payload.get("min_confidence", 0.3)
+            filtered_low = [d for d in result.detections if d.confidence < min_confidence]
+            if filtered_low:
+                logger.info(
+                    "Frame %s: %d detection(s) below min_confidence %.0f%% filtered out: %s",
+                    fid, len(filtered_low), min_confidence * 100,
+                    [(d.label, round(d.confidence * 100)) for d in filtered_low],
+                )
+            result.detections = [d for d in result.detections if d.confidence >= min_confidence]
+
+            # 2. Pattern filter: keep only labels matching the client regex
+            #    (e.g. "(person)" to ignore dog/cat detections).
+            pattern = payload.get("pattern", ".*")
+            if pattern and pattern != ".*":
+                from pyzm.ml.filters import filter_by_pattern
+                result.detections = filter_by_pattern(result.detections, pattern)
+
             data = result.to_dict()
             data.pop("image", None)
             data["frame_id"] = fid
+
+            # 3. Zone filter + short-circuit: check whether any surviving
+            #    detection falls inside the requested zone polygons.
+            #    When stop_on_match is True (default) we stop as soon as we
+            #    find a frame with an in-zone detection, avoiding unnecessary
+            #    inference on the remaining frames.
+            zones_data = payload.get("zones", [])
+            has_zone_match = True
+            if zones_data and result.detections:
+                from pyzm.ml.filters import filter_by_zone
+                h, w = image.shape[:2]
+                kept, _ = filter_by_zone(result.detections, zones_data, (h, w))
+                has_zone_match = len(kept) > 0
+
             results.append(data)
+            if payload.get("stop_on_match", True) and data.get("labels") and has_zone_match:
+                break
 
         return {"results": results}
 

--- a/tests/test_ml/test_detector.py
+++ b/tests/test_ml/test_detector.py
@@ -787,7 +787,7 @@ class TestDetectorRemoteMode:
 
     @patch("pyzm.ml.detector.Detector._remote_detect_urls")
     def test_detect_event_url_mode_default_frame_set(self, mock_remote_urls):
-        """URL-mode with empty frame_set defaults to ['snapshot']."""
+        """URL-mode: empty frame_set + no max_frames falls back to [snapshot, alarm, 1]."""
         from pyzm.ml.detector import Detector
 
         mock_remote_urls.return_value = DetectionResult()
@@ -799,12 +799,14 @@ class TestDetectorRemoteMode:
         mock_zm.api.config.verify_ssl = True
 
         from pyzm.models.config import StreamConfig
-        sc = StreamConfig(frame_set=[])
+        sc = StreamConfig(frame_set=[], max_frames=0)
 
         det.detect_event(mock_zm, 999, stream_config=sc)
         frame_urls = mock_remote_urls.call_args[0][0]
-        assert len(frame_urls) == 1
+        assert len(frame_urls) == 3
         assert frame_urls[0]["frame_id"] == "snapshot"
+        assert frame_urls[1]["frame_id"] == "alarm"
+        assert frame_urls[2]["frame_id"] == "1"
 
     def test_detect_event_url_mode_requires_api(self):
         """URL-mode raises AttributeError if zm_client has no .api."""
@@ -1748,3 +1750,95 @@ class TestRemoteDetectUrlsFiltering:
 
         result = det._remote_detect_urls([], zm_auth="")
         assert not result.matched
+
+
+class TestDetectEventFrameSelection:
+    """Tests for the three-way frame selection logic in detect_event (URL gateway mode)."""
+
+    def _make_detector(self, gateway="http://gpu:5000"):
+        from pyzm.ml.detector import Detector
+        det = Detector.__new__(Detector)
+        det._config = DetectorConfig(pattern=".*")
+        det._pipeline = None
+        det._gateway = gateway
+        det._gateway_mode = "url"
+        det._gateway_token = None
+        det._gateway_timeout = 10
+        det._gateway_username = None
+        det._gateway_password = None
+        return det
+
+    def _make_zm_client(self, portal="http://zm"):
+        zm = MagicMock()
+        zm.api.portal_url = portal
+        zm.api.auth.get_auth_string.return_value = "token=abc"
+        zm.api.config.verify_ssl = True
+        return zm
+
+    @patch("pyzm.ml.detector.requests")
+    def test_frame_set_explicit_uses_frame_set(self, mock_requests):
+        """When frame_set has values, they are used as-is."""
+        from pyzm.models.config import StreamConfig
+        from pyzm.ml.detector import Detector
+
+        det = self._make_detector()
+        zm = self._make_zm_client()
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"results": []}
+        mock_resp.raise_for_status = MagicMock()
+        mock_requests.post.return_value = mock_resp
+
+        sc = StreamConfig(frame_set=["snapshot", "alarm", "50"])
+        try:
+            det.detect_event(zm, event_id=1, stream_config=sc)
+        except Exception:
+            pass
+        call_kwargs = mock_requests.post.call_args.kwargs
+        frame_ids = [u["frame_id"] for u in call_kwargs["json"]["urls"]]
+        assert frame_ids == ["snapshot", "alarm", "50"]
+
+    @patch("pyzm.ml.detector.requests")
+    def test_frame_set_empty_with_max_frames_uses_skip(self, mock_requests):
+        """When frame_set=[] and max_frames>0, uses start_frame+frame_skip."""
+        from pyzm.models.config import StreamConfig
+
+        det = self._make_detector()
+        zm = self._make_zm_client()
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"results": []}
+        mock_resp.raise_for_status = MagicMock()
+        mock_requests.post.return_value = mock_resp
+
+        sc = StreamConfig(frame_set=[], start_frame=50, frame_skip=25, max_frames=4)
+        try:
+            det.detect_event(zm, event_id=1, stream_config=sc)
+        except Exception:
+            pass
+        payload = mock_requests.post.call_args[1]["json"]
+        frame_ids = [u["frame_id"] for u in payload["urls"]]
+        assert frame_ids == ["50", "75", "100", "125"]
+
+    @patch("pyzm.ml.detector.requests")
+    def test_frame_set_empty_without_max_frames_falls_back(self, mock_requests):
+        """When frame_set=[] and max_frames=0, falls back to default snapshot/alarm/1."""
+        from pyzm.models.config import StreamConfig
+
+        det = self._make_detector()
+        zm = self._make_zm_client()
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"results": []}
+        mock_resp.raise_for_status = MagicMock()
+        mock_requests.post.return_value = mock_resp
+
+        sc = StreamConfig(frame_set=[], max_frames=0)
+        try:
+            det.detect_event(zm, event_id=1, stream_config=sc)
+        except Exception:
+            pass
+        # Should fall back to default frame_set
+        call_kwargs = mock_requests.post.call_args.kwargs
+        frame_ids = [u["frame_id"] for u in call_kwargs["json"]["urls"]]
+        assert frame_ids == ["snapshot", "alarm", "1"]

--- a/tests/test_serve/test_app.py
+++ b/tests/test_serve/test_app.py
@@ -261,6 +261,7 @@ class TestDetectUrls:
                 {"frame_id": "snapshot", "url": "http://zm/image?fid=snapshot"},
                 {"frame_id": "alarm", "url": "http://zm/image?fid=alarm"},
             ],
+            "stop_on_match": False,
         }
         resp = client.post("/detect_urls", json=payload)
         assert resp.status_code == 200
@@ -268,3 +269,102 @@ class TestDetectUrls:
         assert len(data["results"]) == 2
         assert data["results"][0]["frame_id"] == "snapshot"
         assert data["results"][1]["frame_id"] == "alarm"
+
+    @pytest.mark.integration
+    @patch("pyzm.serve.app.http_requests")
+    def test_detect_urls_404_stops_after_consecutive_misses(self, mock_http, client):
+        """Stops after contig_frames_before_error consecutive 404s."""
+        not_found = MagicMock()
+        not_found.status_code = 404
+        mock_http.get.return_value = not_found
+
+        payload = {
+            "urls": [
+                {"frame_id": str(i), "url": f"http://zm/image?fid={i}"}
+                for i in range(10)
+            ],
+            "contig_frames_before_error": 3,
+            "max_attempts": 1,
+        }
+        resp = client.post("/detect_urls", json=payload)
+        assert resp.status_code == 200
+        # Should have stopped after 3 consecutive 404s, not processed all 10
+        assert mock_http.get.call_count == 3
+
+    @pytest.mark.integration
+    @patch("pyzm.serve.app.http_requests")
+    def test_detect_urls_404_resets_on_success(self, mock_http, client):
+        """Consecutive 404 counter resets when a frame is fetched successfully."""
+        jpeg_bytes = self._make_jpeg_bytes()
+        ok_resp = MagicMock()
+        ok_resp.content = jpeg_bytes
+        ok_resp.status_code = 200
+        ok_resp.raise_for_status = MagicMock()
+
+        not_found = MagicMock()
+        not_found.status_code = 404
+
+        # 2 404s, then 1 success, then 2 more 404s → should not stop (counter resets)
+        # With contig_frames_before_error=3, after reset only 2 consecutive → no stop
+        mock_http.get.side_effect = [not_found, not_found, ok_resp, not_found, not_found]
+
+        payload = {
+            "urls": [
+                {"frame_id": str(i), "url": f"http://zm/image?fid={i}"}
+                for i in range(5)
+            ],
+            "contig_frames_before_error": 3,
+            "max_attempts": 1,
+            "stop_on_match": False,
+        }
+        resp = client.post("/detect_urls", json=payload)
+        assert resp.status_code == 200
+        # All 5 frames should have been attempted
+        assert mock_http.get.call_count == 5
+
+    @pytest.mark.integration
+    @patch("pyzm.serve.app.http_requests")
+    def test_detect_urls_stop_on_match_stops_at_first_match(self, mock_http, client):
+        """stop_on_match=True stops after first frame with detection."""
+        jpeg_bytes = self._make_jpeg_bytes()
+        ok_resp = MagicMock()
+        ok_resp.content = jpeg_bytes
+        ok_resp.status_code = 200
+        ok_resp.raise_for_status = MagicMock()
+        mock_http.get.return_value = ok_resp
+        payload = {
+            "urls": [
+                {"frame_id": "1", "url": "http://zm/image?fid=1"},
+                {"frame_id": "2", "url": "http://zm/image?fid=2"},
+                {"frame_id": "3", "url": "http://zm/image?fid=3"},
+            ],
+            "stop_on_match": True,
+            "min_confidence": 0.5,
+        }
+        resp = client.post("/detect_urls", json=payload)
+        assert resp.status_code == 200
+        data = resp.json()
+        # Mock detector returns person:0.95; should stop after first match
+        assert len(data["results"]) == 1
+        assert mock_http.get.call_count == 1
+    @pytest.mark.integration
+    @patch("pyzm.serve.app.http_requests")
+    def test_detect_urls_confidence_filter(self, mock_http, client):
+        """Detections below min_confidence are filtered out."""
+        jpeg_bytes = self._make_jpeg_bytes()
+        ok_resp = MagicMock()
+        ok_resp.content = jpeg_bytes
+        ok_resp.status_code = 200
+        ok_resp.raise_for_status = MagicMock()
+        mock_http.get.return_value = ok_resp
+
+        payload = {
+            "urls": [{"frame_id": "1", "url": "http://zm/image?fid=1"}],
+            "min_confidence": 0.99,  # Very high threshold — model won't reach it
+        }
+        resp = client.post("/detect_urls", json=payload)
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        # All detections should be filtered out
+        for r in results:
+            assert not r.get("labels")


### PR DESCRIPTION
Frame selection:
- Empty frame_set now uses start_frame/frame_skip/max_frames for sparse sampling; falls back to default ['snapshot','alarm','1'] with a warning when max_frames is not configured

Live event support:
- Gateway retries 404 frames up to max_attempts times with sleep_between_attempts delay before counting as missing
- Stops after contig_frames_before_error consecutive missing frames

Server-side filtering and short-circuit:
- Client forwards min_confidence, pattern and zone polygons to gateway
- Gateway applies confidence, pattern and zone filters before short-circuit
- stop_on_match=True (default) stops on first in-zone match, avoiding unnecessary inference on remaining frames

Multi-worker (CPU):
- New --workers N CLI argument for pyzm.serve
- Each worker loads the model independently via get_app() factory entry point
- log_level propagated to each worker process

New StreamConfig fields: stop_on_match
New ServerConfig fields: workers, log_level
New payload keys: stop_on_match, contig_frames_before_error, max_attempts,
  sleep_between_attempts, min_confidence, pattern, zones

All changes scoped to ml_gateway_mode=url; local mode and image gateway mode are unaffected.