### PR TITLE
feat(db): auto-discover zm.conf across common locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,572 +3,588 @@
 All notable changes to this project will be documented in this file.
 
 
+## [2.3.7] - 2026-06-03
+
+### Bug Fixes
+
+- use absolute logo URL so it renders on PyPI ([fa36e4f](https://github.com/ZoneMinder/pyzmNg/commit/fa36e4fa41e26a760a797927cf0232605eb96464))
+
+### Documentation
+
+- point repo references to ZoneMinder/pyzmNg ([bd8ebbb](https://github.com/ZoneMinder/pyzmNg/commit/bd8ebbbbb583d20d5e9eeeb8029602e793ddbae8))
+
+### Miscellaneous
+
+- bump version to v2.3.7 ([7f219c2](https://github.com/ZoneMinder/pyzmNg/commit/7f219c2cbd0b50a0f2a2bd9eb96b9efc08ba9d8b))
+- finish ZoneMinder/pyzmNg rename sweep ([6c8b9d1](https://github.com/ZoneMinder/pyzmNg/commit/6c8b9d1058746efa29bb4e92189533cc7e4487ea))
+
 ## [2.3.6] - 2026-05-16
 
 ### Bug Fixes
 
-- default convert_snapshot_to_fid to False ([1b5ba74](https://github.com/pliablepixels/pyzm/commit/1b5ba74c44c979a239498f9ee08f1a57c2c213c4))
+- default convert_snapshot_to_fid to False ([1b5ba74](https://github.com/ZoneMinder/pyzmNg/commit/1b5ba74c44c979a239498f9ee08f1a57c2c213c4))
 
 ### Documentation
 
-- explain log path resolution and add testing recipes ([2312b0a](https://github.com/pliablepixels/pyzm/commit/2312b0a13bea7b2e3ead4a6762663ab8e98d92e3))
+- update CHANGELOG for v2.3.6 ([8193f53](https://github.com/ZoneMinder/pyzmNg/commit/8193f53851855d6c65e385e56a16eab066910c20))
+- explain log path resolution and add testing recipes ([2312b0a](https://github.com/ZoneMinder/pyzmNg/commit/2312b0a13bea7b2e3ead4a6762663ab8e98d92e3))
 
 ### Miscellaneous
 
-- bump version to v2.3.6 ([1a9ccd8](https://github.com/pliablepixels/pyzm/commit/1a9ccd842a31e8e46691ebe25e6ff414e4775d97))
+- bump version to v2.3.6 ([1a9ccd8](https://github.com/ZoneMinder/pyzmNg/commit/1a9ccd842a31e8e46691ebe25e6ff414e4775d97))
 
 ## [2.3.5] - 2026-05-12
 
 ### Bug Fixes
 
-- honor ZM_PATH_LOGS from zm.conf in setup_zm_logging ([ad174b7](https://github.com/pliablepixels/pyzm/commit/ad174b7cdb93dbf000e790ea9b717dadb89f2c29))
+- honor ZM_PATH_LOGS from zm.conf in setup_zm_logging ([ad174b7](https://github.com/ZoneMinder/pyzmNg/commit/ad174b7cdb93dbf000e790ea9b717dadb89f2c29))
 
 ### Documentation
 
-- update CHANGELOG for v2.3.5 ([24a16a6](https://github.com/pliablepixels/pyzm/commit/24a16a67c3909e5a699d4390671cd356ad291dac))
-- rename zmNinjaNG to zmNinjaNg for consistent casing ([832db72](https://github.com/pliablepixels/pyzm/commit/832db7248d002c4cd7772159a9fc8fad2f03e8ac))
+- update CHANGELOG for v2.3.5 ([24a16a6](https://github.com/ZoneMinder/pyzmNg/commit/24a16a67c3909e5a699d4390671cd356ad291dac))
+- rename zmNinjaNG to zmNinjaNg for consistent casing ([832db72](https://github.com/ZoneMinder/pyzmNg/commit/832db7248d002c4cd7772159a9fc8fad2f03e8ac))
 
 ### Features
 
-- add get_logpath() and get_log_file() public helpers ([29adfcf](https://github.com/pliablepixels/pyzm/commit/29adfcf2d9f9a8d81a42e86e9a0c92977f44982d))
+- add get_logpath() and get_log_file() public helpers ([29adfcf](https://github.com/ZoneMinder/pyzmNg/commit/29adfcf2d9f9a8d81a42e86e9a0c92977f44982d))
 
 ### Testing
 
-- scope sys.modules mocks to avoid polluting later tests ([d0d6a24](https://github.com/pliablepixels/pyzm/commit/d0d6a248cbbac8fd4c8ef949e391bf7258da2e4b))
+- scope sys.modules mocks to avoid polluting later tests ([d0d6a24](https://github.com/ZoneMinder/pyzmNg/commit/d0d6a248cbbac8fd4c8ef949e391bf7258da2e4b))
 
 ## [2.3.4] - 2026-04-08
 
 ### Bug Fixes
 
-- rescale zone polygons in remote gateway image-upload path ([6b15af1](https://github.com/pliablepixels/pyzm/commit/6b15af17a569f470e02ed5c39711323b5220663e))
+- rescale zone polygons in remote gateway image-upload path ([6b15af1](https://github.com/ZoneMinder/pyzmNg/commit/6b15af17a569f470e02ed5c39711323b5220663e))
 
 ### Documentation
 
-- update CHANGELOG for v2.3.4 ([63e7bfb](https://github.com/pliablepixels/pyzm/commit/63e7bfbd5f5cd024f98ec1a86013df1c76d02294))
-- rename Event Server v7+ to EventServerNg and zmes to zmesNg ([8c0910a](https://github.com/pliablepixels/pyzm/commit/8c0910a11ced92876084da8d1235c757e8560945))
-- removed the tips - not useful ([4674c31](https://github.com/pliablepixels/pyzm/commit/4674c316d3b2a58cbd6bdbeae42a2c9315596c4a))
+- update CHANGELOG for v2.3.4 ([63e7bfb](https://github.com/ZoneMinder/pyzmNg/commit/63e7bfbd5f5cd024f98ec1a86013df1c76d02294))
+- rename Event Server v7+ to EventServerNg and zmes to zmesNg ([8c0910a](https://github.com/ZoneMinder/pyzmNg/commit/8c0910a11ced92876084da8d1235c757e8560945))
+- removed the tips - not useful ([4674c31](https://github.com/ZoneMinder/pyzmNg/commit/4674c316d3b2a58cbd6bdbeae42a2c9315596c4a))
 
 ### Miscellaneous
 
-- ver bump ([a2a036c](https://github.com/pliablepixels/pyzm/commit/a2a036c7b01b08adc8d3d85645317e8576d91ec8))
-- rename project from pyzmv2 to pyzmNg in RTD config ([df09f17](https://github.com/pliablepixels/pyzm/commit/df09f17c56019f5b03eb92d8468d272e68f47766))
-- point RTD logo to logo/ and remove stale copy ([74f2fa1](https://github.com/pliablepixels/pyzm/commit/74f2fa13375ebdf0ec7ad7c280ed71eaedf2f424))
-- logo ([9c4777b](https://github.com/pliablepixels/pyzm/commit/9c4777bcc501e99aa4cf86baf3041e4cb40fdb87))
+- ver bump ([a2a036c](https://github.com/ZoneMinder/pyzmNg/commit/a2a036c7b01b08adc8d3d85645317e8576d91ec8))
+- rename project from pyzmv2 to pyzmNg in RTD config ([df09f17](https://github.com/ZoneMinder/pyzmNg/commit/df09f17c56019f5b03eb92d8468d272e68f47766))
+- point RTD logo to logo/ and remove stale copy ([74f2fa1](https://github.com/ZoneMinder/pyzmNg/commit/74f2fa13375ebdf0ec7ad7c280ed71eaedf2f424))
+- logo ([9c4777b](https://github.com/ZoneMinder/pyzmNg/commit/9c4777bcc501e99aa4cf86baf3041e4cb40fdb87))
 
 ## [2.3.3] - 2026-03-10
 
 ### Documentation
 
-- update CHANGELOG for v2.3.3 ([a87806e](https://github.com/pliablepixels/pyzm/commit/a87806e4568ad43ecb721fd6d50efd164448c357))
-- rename zmNg/zmNinja to zmNinjaNG across all references ([9334fe6](https://github.com/pliablepixels/pyzm/commit/9334fe65905aa11f6d6bdb850edbd4942364c3b8))
-- fix resize default in StreamConfig table (800 → None) ([11e6cad](https://github.com/pliablepixels/pyzm/commit/11e6cad4e9c60aeae5f060371ff4807744374adb))
+- update CHANGELOG for v2.3.3 ([a87806e](https://github.com/ZoneMinder/pyzmNg/commit/a87806e4568ad43ecb721fd6d50efd164448c357))
+- rename zmNg/zmNinja to zmNinjaNG across all references ([9334fe6](https://github.com/ZoneMinder/pyzmNg/commit/9334fe65905aa11f6d6bdb850edbd4942364c3b8))
+- fix resize default in StreamConfig table (800 → None) ([11e6cad](https://github.com/ZoneMinder/pyzmNg/commit/11e6cad4e9c60aeae5f060371ff4807744374adb))
 
 ### Features
 
-- add profile field to Notification model ([098a0e4](https://github.com/pliablepixels/pyzm/commit/098a0e4180d95f692f55e63ace3ee08ab8456f17))
+- add profile field to Notification model ([098a0e4](https://github.com/ZoneMinder/pyzmNg/commit/098a0e4180d95f692f55e63ace3ee08ab8456f17))
 
 ### Miscellaneous
 
-- ver bump ([9d270ee](https://github.com/pliablepixels/pyzm/commit/9d270ee5889b1438223539a44f92f87c9eb2a95b))
+- ver bump ([9d270ee](https://github.com/ZoneMinder/pyzmNg/commit/9d270ee5889b1438223539a44f92f87c9eb2a95b))
 
 ## [2.3.2] - 2026-03-08
 
 ### Bug Fixes
 
-- change StreamConfig.resize default from 800 to None ([ac18a2d](https://github.com/pliablepixels/pyzm/commit/ac18a2da6a5396fb8f72ae1bbcae5acc6801b878))
+- change StreamConfig.resize default from 800 to None ([ac18a2d](https://github.com/ZoneMinder/pyzmNg/commit/ac18a2da6a5396fb8f72ae1bbcae5acc6801b878))
 
 ### Documentation
 
-- update CHANGELOG for v2.3.2 ([96f839d](https://github.com/pliablepixels/pyzm/commit/96f839d9162414a267c5c351b83f4222394d74fc))
-- add AGENTS.md with plan file hygiene instructions ([042bbbd](https://github.com/pliablepixels/pyzm/commit/042bbbdaeed443c8512d6f9b921a85ae07fd99e5))
+- update CHANGELOG for v2.3.2 ([96f839d](https://github.com/ZoneMinder/pyzmNg/commit/96f839d9162414a267c5c351b83f4222394d74fc))
+- add AGENTS.md with plan file hygiene instructions ([042bbbd](https://github.com/ZoneMinder/pyzmNg/commit/042bbbdaeed443c8512d6f9b921a85ae07fd99e5))
 
 ### Miscellaneous
 
-- ver bump ([6cb97ce](https://github.com/pliablepixels/pyzm/commit/6cb97ce156c7b235136819744218d51d610eafda))
+- ver bump ([6cb97ce](https://github.com/ZoneMinder/pyzmNg/commit/6cb97ce156c7b235136819744218d51d610eafda))
 
 ## [2.3.1] - 2026-03-08
 
 ### Bug Fixes
 
-- face_tpu default, shm namedtuple caching, api params copy, dead StreamConfig fields ([8ac5fa8](https://github.com/pliablepixels/pyzm/commit/8ac5fa86fbe1645af7b2491470459bed6efaff15))
-- DB connection leaks, auth URL separator, db.py port parsing ([6b6091c](https://github.com/pliablepixels/pyzm/commit/6b6091c96e974fab292925eb540df4bee6cb2b80))
-- serve/app.py — FIRST_NEW, original_shape, detector_config, DRY zones ([125256d](https://github.com/pliablepixels/pyzm/commit/125256d25b3f31b3faf69ea1692eff760f2aba43))
-- ignore_pattern should not short-circuit zone matching ([4f31fff](https://github.com/pliablepixels/pyzm/commit/4f31fff9137ddaac589d0466f60715907bd6ad83))
-- release face_dlib lock on exception (prevent deadlock) ([682f869](https://github.com/pliablepixels/pyzm/commit/682f869d609491dc8f642e1332214da0e7e45b07))
-- read max_lock_wait and max_processes from YAML config ([589eafc](https://github.com/pliablepixels/pyzm/commit/589eafccb148bc18eeca8b8184f9820cbc69f21d))
-- populate ModelConfig.options from YAML sequence items ([524503c](https://github.com/pliablepixels/pyzm/commit/524503cbc8706d5ea2b9116b6d9aa6dbf46f19c0))
-- handle YAML booleans in config parsing (true/false vs yes/no) ([d14b119](https://github.com/pliablepixels/pyzm/commit/d14b119966a5096eb5a0aa076f44dc172abc4979))
+- face_tpu default, shm namedtuple caching, api params copy, dead StreamConfig fields ([8ac5fa8](https://github.com/ZoneMinder/pyzmNg/commit/8ac5fa86fbe1645af7b2491470459bed6efaff15))
+- DB connection leaks, auth URL separator, db.py port parsing ([6b6091c](https://github.com/ZoneMinder/pyzmNg/commit/6b6091c96e974fab292925eb540df4bee6cb2b80))
+- serve/app.py — FIRST_NEW, original_shape, detector_config, DRY zones ([125256d](https://github.com/ZoneMinder/pyzmNg/commit/125256d25b3f31b3faf69ea1692eff760f2aba43))
+- ignore_pattern should not short-circuit zone matching ([4f31fff](https://github.com/ZoneMinder/pyzmNg/commit/4f31fff9137ddaac589d0466f60715907bd6ad83))
+- release face_dlib lock on exception (prevent deadlock) ([682f869](https://github.com/ZoneMinder/pyzmNg/commit/682f869d609491dc8f642e1332214da0e7e45b07))
+- read max_lock_wait and max_processes from YAML config ([589eafc](https://github.com/ZoneMinder/pyzmNg/commit/589eafccb148bc18eeca8b8184f9820cbc69f21d))
+- populate ModelConfig.options from YAML sequence items ([524503c](https://github.com/ZoneMinder/pyzmNg/commit/524503cbc8706d5ea2b9116b6d9aa6dbf46f19c0))
+- handle YAML booleans in config parsing (true/false vs yes/no) ([d14b119](https://github.com/ZoneMinder/pyzmNg/commit/d14b119966a5096eb5a0aa076f44dc172abc4979))
 
 ### Documentation
 
-- update CHANGELOG for v2.3.1 ([81f0e46](https://github.com/pliablepixels/pyzm/commit/81f0e465a630ef66341adc39c3dfe64f92bfa388))
+- update CHANGELOG for v2.3.1 ([81f0e46](https://github.com/ZoneMinder/pyzmNg/commit/81f0e465a630ef66341adc39c3dfe64f92bfa388))
 
 ### Features
 
-- client-side filtering for remote detection ([8704984](https://github.com/pliablepixels/pyzm/commit/870498443c8265347443f871cf6985830d015ebc))
-- include detection_types in wire format for remote filtering ([b000ede](https://github.com/pliablepixels/pyzm/commit/b000edee120e4e76e0b869522b003a180b413208))
+- client-side filtering for remote detection ([8704984](https://github.com/ZoneMinder/pyzmNg/commit/870498443c8265347443f871cf6985830d015ebc))
+- include detection_types in wire format for remote filtering ([b000ede](https://github.com/ZoneMinder/pyzmNg/commit/b000edee120e4e76e0b869522b003a180b413208))
 
 ### Miscellaneous
 
-- ver bump ([e4e335b](https://github.com/pliablepixels/pyzm/commit/e4e335bc74975f1679bbda840a872abe1171633f))
-- remove dead filter_past_detections wrapper ([1846e99](https://github.com/pliablepixels/pyzm/commit/1846e99081c41ccddfc3d7eba0b8e8a29671ca79))
+- ver bump ([e4e335b](https://github.com/ZoneMinder/pyzmNg/commit/e4e335bc74975f1679bbda840a872abe1171633f))
+- remove dead filter_past_detections wrapper ([1846e99](https://github.com/ZoneMinder/pyzmNg/commit/1846e99081c41ccddfc3d7eba0b8e8a29671ca79))
 
 ### Refactoring
 
-- extract filter_past_per_type into standalone function ([081e2e5](https://github.com/pliablepixels/pyzm/commit/081e2e53951ee31b9e2bf244e5d7602f9c552f24))
-- server endpoints return raw detections, no filtering ([8c5a445](https://github.com/pliablepixels/pyzm/commit/8c5a44598909ba2f7e8fc24d7dd7f70c8c8135bc))
-- remove dead downscaling code and duplicate import from face_dlib ([c5a18f9](https://github.com/pliablepixels/pyzm/commit/c5a18f9785c93b1b850affde73f17be647c2be47))
+- extract filter_past_per_type into standalone function ([081e2e5](https://github.com/ZoneMinder/pyzmNg/commit/081e2e53951ee31b9e2bf244e5d7602f9c552f24))
+- server endpoints return raw detections, no filtering ([8c5a445](https://github.com/ZoneMinder/pyzmNg/commit/8c5a44598909ba2f7e8fc24d7dd7f70c8c8135bc))
+- remove dead downscaling code and duplicate import from face_dlib ([c5a18f9](https://github.com/ZoneMinder/pyzmNg/commit/c5a18f9785c93b1b850affde73f17be647c2be47))
 
 ### Testing
 
-- update e2e remote tests for thin server ([60b883b](https://github.com/pliablepixels/pyzm/commit/60b883b2d4c4cad211589d930976cf8373a8094f))
-- comprehensive config variant tests for local and remote modes ([79d28fb](https://github.com/pliablepixels/pyzm/commit/79d28fbeb07deb073d81c1bba31cf7c492a4ada8))
+- update e2e remote tests for thin server ([60b883b](https://github.com/ZoneMinder/pyzmNg/commit/60b883b2d4c4cad211589d930976cf8373a8094f))
+- comprehensive config variant tests for local and remote modes ([79d28fb](https://github.com/ZoneMinder/pyzmNg/commit/79d28fbeb07deb073d81c1bba31cf7c492a4ada8))
 
 ## [2.3.0] - 2026-03-06
 
 ### Documentation
 
-- update CHANGELOG for v2.3.0 ([370a118](https://github.com/pliablepixels/pyzm/commit/370a1183263386128da751da7d5acf41a9108b91))
-- add Notification model documentation to zm_client guide ([03a1d4b](https://github.com/pliablepixels/pyzm/commit/03a1d4b09ad2bedda142381c1b579c46d845bb6e))
+- update CHANGELOG for v2.3.0 ([370a118](https://github.com/ZoneMinder/pyzmNg/commit/370a1183263386128da751da7d5acf41a9108b91))
+- add Notification model documentation to zm_client guide ([03a1d4b](https://github.com/ZoneMinder/pyzmNg/commit/03a1d4b09ad2bedda142381c1b579c46d845bb6e))
 
 ### Features
 
-- add Notification model and ZMClient methods for push token registration ([ffeb58a](https://github.com/pliablepixels/pyzm/commit/ffeb58a2fe073ffe6b71ff4befea35db84535929))
+- add Notification model and ZMClient methods for push token registration ([ffeb58a](https://github.com/ZoneMinder/pyzmNg/commit/ffeb58a2fe073ffe6b71ff4befea35db84535929))
 
 ### Miscellaneous
 
-- bump pyzm to 2.3.0 ([fd4f284](https://github.com/pliablepixels/pyzm/commit/fd4f284c817b6900c9bdc0bc00d929b70aeb84d3))
+- bump pyzm to 2.3.0 ([fd4f284](https://github.com/ZoneMinder/pyzmNg/commit/fd4f284c817b6900c9bdc0bc00d929b70aeb84d3))
 
 ### Refactoring
 
-- lazy-fetch monitor dimensions for zone percent conversion ([035dd63](https://github.com/pliablepixels/pyzm/commit/035dd630f36eb238124662f6172096d8831c1743))
+- lazy-fetch monitor dimensions for zone percent conversion ([035dd63](https://github.com/ZoneMinder/pyzmNg/commit/035dd630f36eb238124662f6172096d8831c1743))
 
 ## [2.2.0] - 2026-03-02
 
 ### Bug Fixes
 
-- parse float zone coordinates from ZM 1.37+ ([f1948e8](https://github.com/pliablepixels/pyzm/commit/f1948e88587c62704b014bd2e4224e71e155c9fc))
+- parse float zone coordinates from ZM 1.37+ ([f1948e8](https://github.com/ZoneMinder/pyzmNg/commit/f1948e88587c62704b014bd2e4224e71e155c9fc))
 
 ### Documentation
 
-- update CHANGELOG for v2.2.0 ([a8b7b78](https://github.com/pliablepixels/pyzm/commit/a8b7b78f5e171c03add0ac23fda9cb9a564cf3d0))
-- document annotate() params and Event.save_objdetect() ([6a06113](https://github.com/pliablepixels/pyzm/commit/6a061132fa5c9495f342a71575019549168fb3b8))
+- update CHANGELOG for v2.2.0 ([a8b7b78](https://github.com/ZoneMinder/pyzmNg/commit/a8b7b78f5e171c03add0ac23fda9cb9a564cf3d0))
+- document annotate() params and Event.save_objdetect() ([6a06113](https://github.com/ZoneMinder/pyzmNg/commit/6a061132fa5c9495f342a71575019549168fb3b8))
 
 ### Features
 
-- add Event.save_objdetect() for writing detection artifacts ([7627ae9](https://github.com/pliablepixels/pyzm/commit/7627ae951f723ac16f7f1381c0333c78d583009a))
-- extend annotate() with polygons, write_conf, draw_error_boxes ([967aa8d](https://github.com/pliablepixels/pyzm/commit/967aa8d48db3d55e1cbfc4974278a7e3faa26414))
+- add Event.save_objdetect() for writing detection artifacts ([7627ae9](https://github.com/ZoneMinder/pyzmNg/commit/7627ae951f723ac16f7f1381c0333c78d583009a))
+- extend annotate() with polygons, write_conf, draw_error_boxes ([967aa8d](https://github.com/ZoneMinder/pyzmNg/commit/967aa8d48db3d55e1cbfc4974278a7e3faa26414))
 
 ### Miscellaneous
 
-- docs ([23be59f](https://github.com/pliablepixels/pyzm/commit/23be59ff7398bf407d490243e34ba763ec12a6ba))
+- docs ([23be59f](https://github.com/ZoneMinder/pyzmNg/commit/23be59ff7398bf407d490243e34ba763ec12a6ba))
 
 ## [2.1.9] - 2026-03-01
 
 ### Bug Fixes
 
-- default convert_snapshot_to_fid to True ([44e418d](https://github.com/pliablepixels/pyzm/commit/44e418d3738cf0506bdde10d759045f48fc8fda0))
+- default convert_snapshot_to_fid to True ([44e418d](https://github.com/ZoneMinder/pyzmNg/commit/44e418d3738cf0506bdde10d759045f48fc8fda0))
 
 ### Documentation
 
-- update CHANGELOG for v2.1.9 ([521ebe6](https://github.com/pliablepixels/pyzm/commit/521ebe6013b88dab21b7902a0287b7e6486fa40d))
+- update CHANGELOG for v2.1.9 ([521ebe6](https://github.com/ZoneMinder/pyzmNg/commit/521ebe6013b88dab21b7902a0287b7e6486fa40d))
 
 ### Features
 
-- accept both data.yaml and data.yml for YOLO datasets ([b3ca670](https://github.com/pliablepixels/pyzm/commit/b3ca670525a6c14ffc32756333261441a35d678d))
+- accept both data.yaml and data.yml for YOLO datasets ([b3ca670](https://github.com/ZoneMinder/pyzmNg/commit/b3ca670525a6c14ffc32756333261441a35d678d))
 
 ### Miscellaneous
 
-- bump version to v2.1.9 ([8454c0b](https://github.com/pliablepixels/pyzm/commit/8454c0bb35c40485c0226bf85844a6c5e664952d))
+- bump version to v2.1.9 ([8454c0b](https://github.com/ZoneMinder/pyzmNg/commit/8454c0bb35c40485c0226bf85844a6c5e664952d))
 
 ## [2.1.8] - 2026-02-25
 
 ### Bug Fixes
 
-- include logo in package for non-editable installs ([36d700d](https://github.com/pliablepixels/pyzm/commit/36d700d96cd6f44f57d0f8ca94b4702f2a002d97))
+- include logo in package for non-editable installs ([36d700d](https://github.com/ZoneMinder/pyzmNg/commit/36d700d96cd6f44f57d0f8ca94b4702f2a002d97))
 
 ### Documentation
 
-- update CHANGELOG for v2.1.8 ([0bd7d75](https://github.com/pliablepixels/pyzm/commit/0bd7d756c8fb8cb05e68991962fff2e75186c2bd))
-- clarified not to use pypi for custom opencv installs ([54b3166](https://github.com/pliablepixels/pyzm/commit/54b31661d7df22d4373643ac6cce54f20b0a172f))
+- update CHANGELOG for v2.1.8 ([0bd7d75](https://github.com/ZoneMinder/pyzmNg/commit/0bd7d756c8fb8cb05e68991962fff2e75186c2bd))
+- clarified not to use pypi for custom opencv installs ([54b3166](https://github.com/ZoneMinder/pyzmNg/commit/54b31661d7df22d4373643ac6cce54f20b0a172f))
 
 ### Miscellaneous
 
-- bump version to v2.1.8 ([02e9467](https://github.com/pliablepixels/pyzm/commit/02e94673bf231fc9e340c85d5689a0266580eff3))
+- bump version to v2.1.8 ([02e9467](https://github.com/ZoneMinder/pyzmNg/commit/02e94673bf231fc9e340c85d5689a0266580eff3))
 
 ## [2.1.7] - 2026-02-23
 
 ### Bug Fixes
 
-- restore import path for existing projects and add class filtering ([3e57145](https://github.com/pliablepixels/pyzm/commit/3e57145925aca29b535a5b3ef486bdcdb138b01b))
+- restore import path for existing projects and add class filtering ([3e57145](https://github.com/ZoneMinder/pyzmNg/commit/3e57145925aca29b535a5b3ef486bdcdb138b01b))
 
 ### Documentation
 
-- update CHANGELOG for v2.1.7 ([90dce2e](https://github.com/pliablepixels/pyzm/commit/90dce2e20c68bac86408a46e842c79fcf6418600))
-- fix training guide discrepancies with codebase ([6a0e64b](https://github.com/pliablepixels/pyzm/commit/6a0e64b8a22dd760e95783e1854835c64333635d))
-- update training guide for annotation strategy and --correct workflow ([2f26b23](https://github.com/pliablepixels/pyzm/commit/2f26b23fd5e54c5ebec1fd7a09ad3fee2fe0890d))
-- update training guide for mode-based augmentation and UI changes ([618e44d](https://github.com/pliablepixels/pyzm/commit/618e44d7ec1d08a0aff4e58691de18c9edd77b70))
-- add testing section for fine-tuned models ([6951cf3](https://github.com/pliablepixels/pyzm/commit/6951cf343ba87542224f481227f704111134bfc2))
+- update CHANGELOG for v2.1.7 ([90dce2e](https://github.com/ZoneMinder/pyzmNg/commit/90dce2e20c68bac86408a46e842c79fcf6418600))
+- fix training guide discrepancies with codebase ([6a0e64b](https://github.com/ZoneMinder/pyzmNg/commit/6a0e64b8a22dd760e95783e1854835c64333635d))
+- update training guide for annotation strategy and --correct workflow ([2f26b23](https://github.com/ZoneMinder/pyzmNg/commit/2f26b23fd5e54c5ebec1fd7a09ad3fee2fe0890d))
+- update training guide for mode-based augmentation and UI changes ([618e44d](https://github.com/ZoneMinder/pyzmNg/commit/618e44d7ec1d08a0aff4e58691de18c9edd77b70))
+- add testing section for fine-tuned models ([6951cf3](https://github.com/ZoneMinder/pyzmNg/commit/6951cf343ba87542224f481227f704111134bfc2))
 
 ### Features
 
-- annotation guidance, bulk cleanup, and streamlined UI ([28ab194](https://github.com/pliablepixels/pyzm/commit/28ab194bf70edfa12e875b114015f27dca717f39))
-- headless --correct workflow for batch detect-and-retrain ([bd8d1b6](https://github.com/pliablepixels/pyzm/commit/bd8d1b6bbcceaf863b5cf2f4cb9983a37a55cc00))
-- collapsible step UI with green checkmarks and auto-ONNX export ([94e4b67](https://github.com/pliablepixels/pyzm/commit/94e4b67137310d343fb1824eda8295c2157d04cf))
-- mode-based augmentation for new_class vs refine fine-tuning ([e1bdb5d](https://github.com/pliablepixels/pyzm/commit/e1bdb5d5f38642b27d9c23a5a1b66ff9bd442395))
-- adaptive fine-tuning hyperparameters based on dataset size ([9d89075](https://github.com/pliablepixels/pyzm/commit/9d890754b1ff49639b7927e6d4b2bfe309f53726))
-- restore previous training results when reopening a project ([f0905e4](https://github.com/pliablepixels/pyzm/commit/f0905e4cc81f03af767a229224beb2432627fd11))
-- add test_finetuned_model example script ([567943e](https://github.com/pliablepixels/pyzm/commit/567943ecad3c001a83cb3cc955a33b0347e6692c))
+- annotation guidance, bulk cleanup, and streamlined UI ([28ab194](https://github.com/ZoneMinder/pyzmNg/commit/28ab194bf70edfa12e875b114015f27dca717f39))
+- headless --correct workflow for batch detect-and-retrain ([bd8d1b6](https://github.com/ZoneMinder/pyzmNg/commit/bd8d1b6bbcceaf863b5cf2f4cb9983a37a55cc00))
+- collapsible step UI with green checkmarks and auto-ONNX export ([94e4b67](https://github.com/ZoneMinder/pyzmNg/commit/94e4b67137310d343fb1824eda8295c2157d04cf))
+- mode-based augmentation for new_class vs refine fine-tuning ([e1bdb5d](https://github.com/ZoneMinder/pyzmNg/commit/e1bdb5d5f38642b27d9c23a5a1b66ff9bd442395))
+- adaptive fine-tuning hyperparameters based on dataset size ([9d89075](https://github.com/ZoneMinder/pyzmNg/commit/9d890754b1ff49639b7927e6d4b2bfe309f53726))
+- restore previous training results when reopening a project ([f0905e4](https://github.com/ZoneMinder/pyzmNg/commit/f0905e4cc81f03af767a229224beb2432627fd11))
+- add test_finetuned_model example script ([567943e](https://github.com/ZoneMinder/pyzmNg/commit/567943ecad3c001a83cb3cc955a33b0347e6692c))
 
 ### Miscellaneous
 
-- bump version to v2.1.7 ([7ecb2d3](https://github.com/pliablepixels/pyzm/commit/7ecb2d3e92fc07ff3b7ce840c21c64ab427eb81c))
+- bump version to v2.1.7 ([7ecb2d3](https://github.com/ZoneMinder/pyzmNg/commit/7ecb2d3e92fc07ff3b7ce840c21c64ab427eb81c))
 
 ## [2.1.6] - 2026-02-22
 
 ### Bug Fixes
 
-- add path traversal guards and replace ast.literal_eval ([d4a8cb3](https://github.com/pliablepixels/pyzm/commit/d4a8cb3d72d207f104cb3cefe60f5c97d6e2f7de))
-- clamp annotation coords and add auto-label confidence threshold ([780dbd8](https://github.com/pliablepixels/pyzm/commit/780dbd8d7ae19216abb389d57e2d3f06fd8b16cf))
-- stop persisting ZM password in plaintext ([84f80a1](https://github.com/pliablepixels/pyzm/commit/84f80a1c9a4452dc70ae6185328eab4d0dd07a0c))
-- batch size formula, add training resume, fix CSV parsing ([320a5e8](https://github.com/pliablepixels/pyzm/commit/320a5e8761fbf2dc9dedcc24dfa734acdb527aba))
-- fix NameError, inconsistent resize, and dead code in face_train_dlib ([6bfaa68](https://github.com/pliablepixels/pyzm/commit/6bfaa68bb09c2ffec5794aa971114af48538e463))
-- align streamlit version check with setup.py requirement ([7d3dc69](https://github.com/pliablepixels/pyzm/commit/7d3dc6921301dfaed5924fdbb1452d5f046e3d14))
-- move streamlit import to avoid breaking headless mode ([ae46723](https://github.com/pliablepixels/pyzm/commit/ae467237eb613c441c938d69020ac9ec30bd6405))
-- remove hardcoded developer IP from ZM browser default URL ([590a862](https://github.com/pliablepixels/pyzm/commit/590a862ed751937b39da4f95667ab80a707e6b9a))
-- fall back to Storage Id=1 when event's StorageId is invalid ([c9f81b2](https://github.com/pliablepixels/pyzm/commit/c9f81b2b9b0bed8c2dc9e81c363eaf9b389394c6))
+- add path traversal guards and replace ast.literal_eval ([d4a8cb3](https://github.com/ZoneMinder/pyzmNg/commit/d4a8cb3d72d207f104cb3cefe60f5c97d6e2f7de))
+- clamp annotation coords and add auto-label confidence threshold ([780dbd8](https://github.com/ZoneMinder/pyzmNg/commit/780dbd8d7ae19216abb389d57e2d3f06fd8b16cf))
+- stop persisting ZM password in plaintext ([84f80a1](https://github.com/ZoneMinder/pyzmNg/commit/84f80a1c9a4452dc70ae6185328eab4d0dd07a0c))
+- batch size formula, add training resume, fix CSV parsing ([320a5e8](https://github.com/ZoneMinder/pyzmNg/commit/320a5e8761fbf2dc9dedcc24dfa734acdb527aba))
+- fix NameError, inconsistent resize, and dead code in face_train_dlib ([6bfaa68](https://github.com/ZoneMinder/pyzmNg/commit/6bfaa68bb09c2ffec5794aa971114af48538e463))
+- align streamlit version check with setup.py requirement ([7d3dc69](https://github.com/ZoneMinder/pyzmNg/commit/7d3dc6921301dfaed5924fdbb1452d5f046e3d14))
+- move streamlit import to avoid breaking headless mode ([ae46723](https://github.com/ZoneMinder/pyzmNg/commit/ae467237eb613c441c938d69020ac9ec30bd6405))
+- remove hardcoded developer IP from ZM browser default URL ([590a862](https://github.com/ZoneMinder/pyzmNg/commit/590a862ed751937b39da4f95667ab80a707e6b9a))
+- fall back to Storage Id=1 when event's StorageId is invalid ([c9f81b2](https://github.com/ZoneMinder/pyzmNg/commit/c9f81b2b9b0bed8c2dc9e81c363eaf9b389394c6))
 
 ### Documentation
 
-- update CHANGELOG for v2.1.6 ([f1a69fd](https://github.com/pliablepixels/pyzm/commit/f1a69fd7f651d92639fd39e4bfe2af5fe31a6fed))
+- update CHANGELOG for v2.1.6 ([f1a69fd](https://github.com/ZoneMinder/pyzmNg/commit/f1a69fd7f651d92639fd39e4bfe2af5fe31a6fed))
 
 ### Features
 
-- add --max-per-class CLI option and fix Ultralytics 8.4.x compat ([3a212e0](https://github.com/pliablepixels/pyzm/commit/3a212e031e896ea08104b0666cf5a411fdddc3e0))
-- add bulk approve, undo, and image deletion in review ([c7c67e8](https://github.com/pliablepixels/pyzm/commit/c7c67e873a1c83c4df6bf75d232ddcbcf8a24815))
-- improve training UI with plain-English metrics and onboarding ([1469962](https://github.com/pliablepixels/pyzm/commit/14699621caedb51099486f0925cee23f9977ec92))
+- add --max-per-class CLI option and fix Ultralytics 8.4.x compat ([3a212e0](https://github.com/ZoneMinder/pyzmNg/commit/3a212e031e896ea08104b0666cf5a411fdddc3e0))
+- add bulk approve, undo, and image deletion in review ([c7c67e8](https://github.com/ZoneMinder/pyzmNg/commit/c7c67e873a1c83c4df6bf75d232ddcbcf8a24815))
+- improve training UI with plain-English metrics and onboarding ([1469962](https://github.com/ZoneMinder/pyzmNg/commit/14699621caedb51099486f0925cee23f9977ec92))
 
 ### Miscellaneous
 
-- pyzm bump ([d79f60c](https://github.com/pliablepixels/pyzm/commit/d79f60c54ea59d9533d1797830ecab2d58b18342))
+- pyzm bump ([d79f60c](https://github.com/ZoneMinder/pyzmNg/commit/d79f60c54ea59d9533d1797830ecab2d58b18342))
 
 ### Refactoring
 
-- split app.py into phase-specific panel modules ([4199674](https://github.com/pliablepixels/pyzm/commit/41996748a01ab7a7e7b125d61364d106a00d5039))
-- simplify _event_path to use Storage table directly via StorageId ([d4b7108](https://github.com/pliablepixels/pyzm/commit/d4b710826f032b7dbe35da5239e2f9480f25cb7e))
+- split app.py into phase-specific panel modules ([4199674](https://github.com/ZoneMinder/pyzmNg/commit/41996748a01ab7a7e7b125d61364d106a00d5039))
+- simplify _event_path to use Storage table directly via StorageId ([d4b7108](https://github.com/ZoneMinder/pyzmNg/commit/d4b710826f032b7dbe35da5239e2f9480f25cb7e))
 
 ### Testing
 
-- add pipeline and CLI tests, fill coverage gaps ([19a9bd3](https://github.com/pliablepixels/pyzm/commit/19a9bd31cc2e6f1fd79a2fafed7877535de95d43))
+- add pipeline and CLI tests, fill coverage gaps ([19a9bd3](https://github.com/ZoneMinder/pyzmNg/commit/19a9bd31cc2e6f1fd79a2fafed7877535de95d43))
 
 ## [2.1.5] - 2026-02-22
 
 ### Bug Fixes
 
-- fall back to default Storage row when ZM_DIR_EVENTS missing ([cf4d442](https://github.com/pliablepixels/pyzm/commit/cf4d4427010659c57df23ddfb1b3076ca6d354dc))
-- handle StorageId=0 in _event_path by falling back to ZM_DIR_EVENTS ([03e71cb](https://github.com/pliablepixels/pyzm/commit/03e71cbed3e84359ccadb70862571f7b4b3bf253))
+- fall back to default Storage row when ZM_DIR_EVENTS missing ([cf4d442](https://github.com/ZoneMinder/pyzmNg/commit/cf4d4427010659c57df23ddfb1b3076ca6d354dc))
+- handle StorageId=0 in _event_path by falling back to ZM_DIR_EVENTS ([03e71cb](https://github.com/ZoneMinder/pyzmNg/commit/03e71cbed3e84359ccadb70862571f7b4b3bf253))
 
 ### Documentation
 
-- update CHANGELOG for v2.1.5 ([d94b15f](https://github.com/pliablepixels/pyzm/commit/d94b15f5805908feaba068cfe6853407178d1e14))
+- update CHANGELOG for v2.1.5 ([d94b15f](https://github.com/ZoneMinder/pyzmNg/commit/d94b15f5805908feaba068cfe6853407178d1e14))
 
 ## [2.1.4] - 2026-02-22
 
 ### Bug Fixes
 
-- downgrade zm.conf warning to debug when explicit DB creds provided ([b6e0a97](https://github.com/pliablepixels/pyzm/commit/b6e0a978ef6a19a5837bd7e8b18f878f708a8306))
+- downgrade zm.conf warning to debug when explicit DB creds provided ([b6e0a97](https://github.com/ZoneMinder/pyzmNg/commit/b6e0a978ef6a19a5837bd7e8b18f878f708a8306))
 
 ### Documentation
 
-- update CHANGELOG for v2.1.4 ([9103b6b](https://github.com/pliablepixels/pyzm/commit/9103b6bb8f4084fdf61a6d970f9f3c34c5f903f4))
-- expand face recognition install with BLAS and reinstall steps ([0a1594e](https://github.com/pliablepixels/pyzm/commit/0a1594e2a9342fb2e2c9310a09214b32ec9830e7))
-- took out some arch notes ([539b4ec](https://github.com/pliablepixels/pyzm/commit/539b4ec20669d317ddeb8529c592266ff242179b))
-- comprehensive accuracy and completeness audit of all guide pages ([785c65c](https://github.com/pliablepixels/pyzm/commit/785c65cf78c160bad08dcfc58cd15ee30fda9055))
-- move raw() section from events page to client page ([3ab58b4](https://github.com/pliablepixels/pyzm/commit/3ab58b447b8a04e042ebf0e2659e8c8ee006fb85))
-- add upgrading section for PyPI and source installs ([0d843c1](https://github.com/pliablepixels/pyzm/commit/0d843c13750ae34c790fa1cf23636881027c2c0b))
+- update CHANGELOG for v2.1.4 ([9103b6b](https://github.com/ZoneMinder/pyzmNg/commit/9103b6bb8f4084fdf61a6d970f9f3c34c5f903f4))
+- expand face recognition install with BLAS and reinstall steps ([0a1594e](https://github.com/ZoneMinder/pyzmNg/commit/0a1594e2a9342fb2e2c9310a09214b32ec9830e7))
+- took out some arch notes ([539b4ec](https://github.com/ZoneMinder/pyzmNg/commit/539b4ec20669d317ddeb8529c592266ff242179b))
+- comprehensive accuracy and completeness audit of all guide pages ([785c65c](https://github.com/ZoneMinder/pyzmNg/commit/785c65cf78c160bad08dcfc58cd15ee30fda9055))
+- move raw() section from events page to client page ([3ab58b4](https://github.com/ZoneMinder/pyzmNg/commit/3ab58b447b8a04e042ebf0e2659e8c8ee006fb85))
+- add upgrading section for PyPI and source installs ([0d843c1](https://github.com/ZoneMinder/pyzmNg/commit/0d843c13750ae34c790fa1cf23636881027c2c0b))
 
 ### Features
 
-- pass DB credentials through ZMClientConfig ([7324a65](https://github.com/pliablepixels/pyzm/commit/7324a651474da32218643796227b9662b64a7248))
+- pass DB credentials through ZMClientConfig ([7324a65](https://github.com/ZoneMinder/pyzmNg/commit/7324a651474da32218643796227b9662b64a7248))
 
 ### Miscellaneous
 
-- ver bump ([5f9ee66](https://github.com/pliablepixels/pyzm/commit/5f9ee66a60f8ae98af37f8ac1a5b4bcb11b2ddda))
+- ver bump ([5f9ee66](https://github.com/ZoneMinder/pyzmNg/commit/5f9ee66a60f8ae98af37f8ac1a5b4bcb11b2ddda))
 
 ### Refactoring
 
-- merge legacy ML implementations with backend adapters ([#23](https://github.com/pliablepixels/pyzm/issues/23)) ([583525a](https://github.com/pliablepixels/pyzm/commit/583525a2f0757507d105901470203e2bc9cb4a3e))
+- merge legacy ML implementations with backend adapters ([#23](https://github.com/ZoneMinder/pyzmNg/issues/23)) ([583525a](https://github.com/ZoneMinder/pyzmNg/commit/583525a2f0757507d105901470203e2bc9cb4a3e))
 
 ## [2.1.3] - 2026-02-20
 
 ### Bug Fixes
 
-- auto-detect movement mode from control profile capabilities ([55778ca](https://github.com/pliablepixels/pyzm/commit/55778ca9656094f389b2706db4aeefed015d99b9))
-- read version from file to avoid pydantic import on RTD ([a559941](https://github.com/pliablepixels/pyzm/commit/a5599411b60924c4c93f3452eeb01f3ac40ad9d2))
+- auto-detect movement mode from control profile capabilities ([55778ca](https://github.com/ZoneMinder/pyzmNg/commit/55778ca9656094f389b2706db4aeefed015d99b9))
+- read version from file to avoid pydantic import on RTD ([a559941](https://github.com/ZoneMinder/pyzmNg/commit/a5599411b60924c4c93f3452eeb01f3ac40ad9d2))
 
 ### Documentation
 
-- update CHANGELOG for v2.1.3 ([58bb8fd](https://github.com/pliablepixels/pyzm/commit/58bb8fdf34771fa1d9b7c2f6c7cca0535092751e))
-- restructure sidebar into Getting Started, ZM API, and ML sections ([f5665d1](https://github.com/pliablepixels/pyzm/commit/f5665d19e68fee42f41edb0003579cd57dd5cc49))
+- update CHANGELOG for v2.1.3 ([58bb8fd](https://github.com/ZoneMinder/pyzmNg/commit/58bb8fdf34771fa1d9b7c2f6c7cca0535092751e))
+- restructure sidebar into Getting Started, ZM API, and ML sections ([f5665d1](https://github.com/ZoneMinder/pyzmNg/commit/f5665d19e68fee42f41edb0003579cd57dd5cc49))
 
 ### Miscellaneous
 
-- ver bump ([a4a1c8f](https://github.com/pliablepixels/pyzm/commit/a4a1c8f764a8d27d2af05a1f8a5d7122fa2e6b6d))
+- ver bump ([a4a1c8f](https://github.com/ZoneMinder/pyzmNg/commit/a4a1c8f764a8d27d2af05a1f8a5d7122fa2e6b6d))
 
 ## [2.1.2] - 2026-02-19
 
 ### Bug Fixes
 
-- read version dynamically from pyzm.__version__ in conf.py ([7d349a0](https://github.com/pliablepixels/pyzm/commit/7d349a0e00af8d1e23b9d31000a06c232d6c9e1d))
+- read version dynamically from pyzm.__version__ in conf.py ([7d349a0](https://github.com/ZoneMinder/pyzmNg/commit/7d349a0e00af8d1e23b9d31000a06c232d6c9e1d))
 
 ### Documentation
 
-- update CHANGELOG for v2.1.2 ([0bb5f2e](https://github.com/pliablepixels/pyzm/commit/0bb5f2eef12da0c00c791ca6069c6ee129a545e3))
-- added documentation notes and es reliance ([771a931](https://github.com/pliablepixels/pyzm/commit/771a931cbc1cc2a62f666988c34a57adc583072e))
-- fix inaccuracies and gaps across documentation ([8af47cc](https://github.com/pliablepixels/pyzm/commit/8af47cc74c4ab13dfbbc699f3c7cba3fe62dfa62))
+- update CHANGELOG for v2.1.2 ([0bb5f2e](https://github.com/ZoneMinder/pyzmNg/commit/0bb5f2eef12da0c00c791ca6069c6ee129a545e3))
+- added documentation notes and es reliance ([771a931](https://github.com/ZoneMinder/pyzmNg/commit/771a931cbc1cc2a62f666988c34a57adc583072e))
+- fix inaccuracies and gaps across documentation ([8af47cc](https://github.com/ZoneMinder/pyzmNg/commit/8af47cc74c4ab13dfbbc699f3c7cba3fe62dfa62))
 
 ### Features
 
-- add raw() method to all ZM API model objects ([ba77844](https://github.com/pliablepixels/pyzm/commit/ba77844a3a20915fca6050636257fe6558dc8229))
+- add raw() method to all ZM API model objects ([ba77844](https://github.com/ZoneMinder/pyzmNg/commit/ba77844a3a20915fca6050636257fe6558dc8229))
 
 ### Miscellaneous
 
-- bump version to v2.1.2 ([a752740](https://github.com/pliablepixels/pyzm/commit/a7527402ee5f13f36b98283c97823d5a1b76ebfc))
+- bump version to v2.1.2 ([a752740](https://github.com/ZoneMinder/pyzmNg/commit/a7527402ee5f13f36b98283c97823d5a1b76ebfc))
 
 ## [2.1.1] - 2026-02-18
 
 ### Documentation
 
-- update CHANGELOG for v2.1.1 ([0fd7981](https://github.com/pliablepixels/pyzm/commit/0fd7981d5238f01b2a03be6bb44ff26d97873ac9))
-- fix remote.py docstring to show URL mode as default ([312e667](https://github.com/pliablepixels/pyzm/commit/312e667726d8a81636e8af036b0bf2d289a6b758))
-- add RTD links to all examples ([3e7e455](https://github.com/pliablepixels/pyzm/commit/3e7e455d2edf1f812d1c4e0e5137f2052a6a037d))
-- simplify examples, add URL mode to remote.py ([3110ec1](https://github.com/pliablepixels/pyzm/commit/3110ec17de45bbb5d939f39b782200ff657d4208))
+- update CHANGELOG for v2.1.1 ([0fd7981](https://github.com/ZoneMinder/pyzmNg/commit/0fd7981d5238f01b2a03be6bb44ff26d97873ac9))
+- fix remote.py docstring to show URL mode as default ([312e667](https://github.com/ZoneMinder/pyzmNg/commit/312e667726d8a81636e8af036b0bf2d289a6b758))
+- add RTD links to all examples ([3e7e455](https://github.com/ZoneMinder/pyzmNg/commit/3e7e455d2edf1f812d1c4e0e5137f2052a6a037d))
+- simplify examples, add URL mode to remote.py ([3110ec1](https://github.com/ZoneMinder/pyzmNg/commit/3110ec17de45bbb5d939f39b782200ff657d4208))
 
 ### Features
 
-- accept /login when auth disabled, add --debug flag ([cff3151](https://github.com/pliablepixels/pyzm/commit/cff3151133cefb3e11ec7dc5feeeed9b90474bf7))
-- change default gateway_mode from "image" to "url" ([8d2b675](https://github.com/pliablepixels/pyzm/commit/8d2b67591b1faf7e0cd4da88ac9cedf010c713e0))
+- accept /login when auth disabled, add --debug flag ([cff3151](https://github.com/ZoneMinder/pyzmNg/commit/cff3151133cefb3e11ec7dc5feeeed9b90474bf7))
+- change default gateway_mode from "image" to "url" ([8d2b675](https://github.com/ZoneMinder/pyzmNg/commit/8d2b67591b1faf7e0cd4da88ac9cedf010c713e0))
 
 ### Miscellaneous
 
-- bump version to v2.1.1 ([05fac76](https://github.com/pliablepixels/pyzm/commit/05fac761af125ee858bacc394a7b4d1c12017b53))
+- bump version to v2.1.1 ([05fac76](https://github.com/ZoneMinder/pyzmNg/commit/05fac761af125ee858bacc394a7b4d1c12017b53))
 
 ## [2.1.0] - 2026-02-18
 
 ### Bug Fixes
 
-- download model weights to project_dir, not CWD ([19aef17](https://github.com/pliablepixels/pyzm/commit/19aef179420267a30a26449a90b08f89015552d0))
-- use single file uploader to avoid duplicate uploads ([ee77049](https://github.com/pliablepixels/pyzm/commit/ee770493ad5f4123c197a825f677243d7fca2167))
-- clarify why images are needed for regrouping ([4247c55](https://github.com/pliablepixels/pyzm/commit/4247c559f1761b8036da2776266ab767699612c4))
-- explain auto-detect purpose and hide when not useful ([be796f7](https://github.com/pliablepixels/pyzm/commit/be796f7b2bd895c9be40472ac52cb587a26efd57))
-- fix project load rerun loop and improve layout alignment ([a406802](https://github.com/pliablepixels/pyzm/commit/a406802127c6b107ea191184c4d82bbe1946a38a))
-- use media file manager for canvas background images ([8e9b7f2](https://github.com/pliablepixels/pyzm/commit/8e9b7f20f9063c0cd76306ff0dbf1c7e2408c50d))
-- shim image_to_url for streamlit-drawable-canvas compat ([e360eb2](https://github.com/pliablepixels/pyzm/commit/e360eb2d7c8d5475b5f12f277ea1efa0dd8e712b))
-- fix upload rerun loop and show next steps after upload ([7e6a8a0](https://github.com/pliablepixels/pyzm/commit/7e6a8a00387f896c59ecb4f5287da8a344c3707e))
-- use native Streamlit dark theme instead of injected CSS ([ce1659f](https://github.com/pliablepixels/pyzm/commit/ce1659fef77ec73ad8afffe6cc0862e336b3bf50))
-- scan individual model files, auto-populate classes from ONNX ([900399d](https://github.com/pliablepixels/pyzm/commit/900399d2a30a3f5233de77229759cf1558088c94))
-- use single model for auto-detect, redesign UI flow ([de5e9b8](https://github.com/pliablepixels/pyzm/commit/de5e9b834412c00770ad7f747d3fa6663974f338))
+- download model weights to project_dir, not CWD ([19aef17](https://github.com/ZoneMinder/pyzmNg/commit/19aef179420267a30a26449a90b08f89015552d0))
+- use single file uploader to avoid duplicate uploads ([ee77049](https://github.com/ZoneMinder/pyzmNg/commit/ee770493ad5f4123c197a825f677243d7fca2167))
+- clarify why images are needed for regrouping ([4247c55](https://github.com/ZoneMinder/pyzmNg/commit/4247c559f1761b8036da2776266ab767699612c4))
+- explain auto-detect purpose and hide when not useful ([be796f7](https://github.com/ZoneMinder/pyzmNg/commit/be796f7b2bd895c9be40472ac52cb587a26efd57))
+- fix project load rerun loop and improve layout alignment ([a406802](https://github.com/ZoneMinder/pyzmNg/commit/a406802127c6b107ea191184c4d82bbe1946a38a))
+- use media file manager for canvas background images ([8e9b7f2](https://github.com/ZoneMinder/pyzmNg/commit/8e9b7f20f9063c0cd76306ff0dbf1c7e2408c50d))
+- shim image_to_url for streamlit-drawable-canvas compat ([e360eb2](https://github.com/ZoneMinder/pyzmNg/commit/e360eb2d7c8d5475b5f12f277ea1efa0dd8e712b))
+- fix upload rerun loop and show next steps after upload ([7e6a8a0](https://github.com/ZoneMinder/pyzmNg/commit/7e6a8a00387f896c59ecb4f5287da8a344c3707e))
+- use native Streamlit dark theme instead of injected CSS ([ce1659f](https://github.com/ZoneMinder/pyzmNg/commit/ce1659fef77ec73ad8afffe6cc0862e336b3bf50))
+- scan individual model files, auto-populate classes from ONNX ([900399d](https://github.com/ZoneMinder/pyzmNg/commit/900399d2a30a3f5233de77229759cf1558088c94))
+- use single model for auto-detect, redesign UI flow ([de5e9b8](https://github.com/ZoneMinder/pyzmNg/commit/de5e9b834412c00770ad7f747d3fa6663974f338))
 
 ### Documentation
 
-- update CHANGELOG for v2.1.0 ([1e755fd](https://github.com/pliablepixels/pyzm/commit/1e755fd1e2963855d45c9992a689920f4a3ce097))
-- document all new ZMClient API methods in quickstart ([78e2b7e](https://github.com/pliablepixels/pyzm/commit/78e2b7e617475dead1f52e1801058b50dff65542))
-- add standalone logging guide, fix stale url= references ([82450d9](https://github.com/pliablepixels/pyzm/commit/82450d97a4f5c3f1343f080fa3742b2bed492eb6))
-- add BirdNET to detection guide and feature list ([7186b58](https://github.com/pliablepixels/pyzm/commit/7186b5831669988291e1905264c7615320666208))
-- update birdnet and optional deps for venv install paths ([fa81958](https://github.com/pliablepixels/pyzm/commit/fa81958fab5981ee8ca2d0cec1402e4522b9e213))
-- update RTD logo to match new logo ([cd64bdb](https://github.com/pliablepixels/pyzm/commit/cd64bdb3fd05401bd545986a7b43e3b4bcd1da17))
-- add Coral EdgeTPU deprecation note with pycoral[#149](https://github.com/pliablepixels/pyzm/issues/149) link ([5022a73](https://github.com/pliablepixels/pyzm/commit/5022a7319227124d7f8b5948959524981f5b68e4))
-- add training guide and update install instructions for extras ([f820cee](https://github.com/pliablepixels/pyzm/commit/f820cee8bf14dbfdbd8423d24c1c9c89cd84e713))
-- link zmNg to ReadTheDocs instead of GitHub ([0ecced5](https://github.com/pliablepixels/pyzm/commit/0ecced54a289d54222da458fa89c4983982d20eb))
+- update CHANGELOG for v2.1.0 ([1e755fd](https://github.com/ZoneMinder/pyzmNg/commit/1e755fd1e2963855d45c9992a689920f4a3ce097))
+- document all new ZMClient API methods in quickstart ([78e2b7e](https://github.com/ZoneMinder/pyzmNg/commit/78e2b7e617475dead1f52e1801058b50dff65542))
+- add standalone logging guide, fix stale url= references ([82450d9](https://github.com/ZoneMinder/pyzmNg/commit/82450d97a4f5c3f1343f080fa3742b2bed492eb6))
+- add BirdNET to detection guide and feature list ([7186b58](https://github.com/ZoneMinder/pyzmNg/commit/7186b5831669988291e1905264c7615320666208))
+- update birdnet and optional deps for venv install paths ([fa81958](https://github.com/ZoneMinder/pyzmNg/commit/fa81958fab5981ee8ca2d0cec1402e4522b9e213))
+- update RTD logo to match new logo ([cd64bdb](https://github.com/ZoneMinder/pyzmNg/commit/cd64bdb3fd05401bd545986a7b43e3b4bcd1da17))
+- add Coral EdgeTPU deprecation note with pycoral[#149](https://github.com/ZoneMinder/pyzmNg/issues/149) link ([5022a73](https://github.com/ZoneMinder/pyzmNg/commit/5022a7319227124d7f8b5948959524981f5b68e4))
+- add training guide and update install instructions for extras ([f820cee](https://github.com/ZoneMinder/pyzmNg/commit/f820cee8bf14dbfdbd8423d24c1c9c89cd84e713))
+- link zmNg to ReadTheDocs instead of GitHub ([0ecced5](https://github.com/ZoneMinder/pyzmNg/commit/0ecced54a289d54222da458fa89c4983982d20eb))
 
 ### Features
 
-- add OOP resource methods on Monitor/Event and PTZ control ([f2ea43c](https://github.com/pliablepixels/pyzm/commit/f2ea43ca8f0ce58229b16431dd9d3bba826abb36))
-- add missing ZM API features to ZMClient ([5f88385](https://github.com/pliablepixels/pyzm/commit/5f883852bfa2889bb4a6619a30bd93e4afb842fc))
-- add Detector.detect_audio() and BirdNET examples ([ed77522](https://github.com/pliablepixels/pyzm/commit/ed775229b24eb708f8f207873f31062da603d6bb))
-- add BirdNET audio bird recognition backend ([14771da](https://github.com/pliablepixels/pyzm/commit/14771daaf9527acea2249f64eff87e53d0f1e256))
-- use shared venv instead of --break-system-packages ([05645cd](https://github.com/pliablepixels/pyzm/commit/05645cda7c60c441faae3da61c767a3003ead98f))
-- add headless CLI training pipeline ([d6df249](https://github.com/pliablepixels/pyzm/commit/d6df249bf51b512093b47af1a77e99823192da8f))
-- UI polish, MPS support, folder picker, and docs ([cf7b9a3](https://github.com/pliablepixels/pyzm/commit/cf7b9a39cd37b0017121b20537601cf29f7a9539))
-- grid review UI, recursive ONNX model scan, and local import ([ab54b78](https://github.com/pliablepixels/pyzm/commit/ab54b78bbab5afe88dfda6822e5dec8a52134847))
-- remove Upload phase, add date pickers, and UX improvements ([d32ddd0](https://github.com/pliablepixels/pyzm/commit/d32ddd0356d3d3e82a74b4d0f15e54e5e54b6859))
-- verification-based review workflow and UX improvements ([fb2e349](https://github.com/pliablepixels/pyzm/commit/fb2e349789700e2240fe180e750c35d7bfdc3ab1))
-- skip training for remap-only projects ([b2e5815](https://github.com/pliablepixels/pyzm/commit/b2e58155f28c1418cbbe8f702d18f438b5619adc))
-- labeled annotations, color-coded boxes, min 2 images ([808e304](https://github.com/pliablepixels/pyzm/commit/808e3047d1d0418e4bec69f7186e64cb4e5780a9))
-- add class grouping and dark UI theme ([8bac331](https://github.com/pliablepixels/pyzm/commit/8bac331dcb2b495d4515e13f2891181d7276826e))
-- add YOLO fine-tuning training module (pyzm[train]) ([b47fbab](https://github.com/pliablepixels/pyzm/commit/b47fbab08353c4d7d8111871e18ab7af0cc84e1e))
+- add OOP resource methods on Monitor/Event and PTZ control ([f2ea43c](https://github.com/ZoneMinder/pyzmNg/commit/f2ea43ca8f0ce58229b16431dd9d3bba826abb36))
+- add missing ZM API features to ZMClient ([5f88385](https://github.com/ZoneMinder/pyzmNg/commit/5f883852bfa2889bb4a6619a30bd93e4afb842fc))
+- add Detector.detect_audio() and BirdNET examples ([ed77522](https://github.com/ZoneMinder/pyzmNg/commit/ed775229b24eb708f8f207873f31062da603d6bb))
+- add BirdNET audio bird recognition backend ([14771da](https://github.com/ZoneMinder/pyzmNg/commit/14771daaf9527acea2249f64eff87e53d0f1e256))
+- use shared venv instead of --break-system-packages ([05645cd](https://github.com/ZoneMinder/pyzmNg/commit/05645cda7c60c441faae3da61c767a3003ead98f))
+- add headless CLI training pipeline ([d6df249](https://github.com/ZoneMinder/pyzmNg/commit/d6df249bf51b512093b47af1a77e99823192da8f))
+- UI polish, MPS support, folder picker, and docs ([cf7b9a3](https://github.com/ZoneMinder/pyzmNg/commit/cf7b9a39cd37b0017121b20537601cf29f7a9539))
+- grid review UI, recursive ONNX model scan, and local import ([ab54b78](https://github.com/ZoneMinder/pyzmNg/commit/ab54b78bbab5afe88dfda6822e5dec8a52134847))
+- remove Upload phase, add date pickers, and UX improvements ([d32ddd0](https://github.com/ZoneMinder/pyzmNg/commit/d32ddd0356d3d3e82a74b4d0f15e54e5e54b6859))
+- verification-based review workflow and UX improvements ([fb2e349](https://github.com/ZoneMinder/pyzmNg/commit/fb2e349789700e2240fe180e750c35d7bfdc3ab1))
+- skip training for remap-only projects ([b2e5815](https://github.com/ZoneMinder/pyzmNg/commit/b2e58155f28c1418cbbe8f702d18f438b5619adc))
+- labeled annotations, color-coded boxes, min 2 images ([808e304](https://github.com/ZoneMinder/pyzmNg/commit/808e3047d1d0418e4bec69f7186e64cb4e5780a9))
+- add class grouping and dark UI theme ([8bac331](https://github.com/ZoneMinder/pyzmNg/commit/8bac331dcb2b495d4515e13f2891181d7276826e))
+- add YOLO fine-tuning training module (pyzm[train]) ([b47fbab](https://github.com/ZoneMinder/pyzmNg/commit/b47fbab08353c4d7d8111871e18ab7af0cc84e1e))
 
 ### Miscellaneous
 
-- switch setup.py to find_packages(), clean up install docs ([4521063](https://github.com/pliablepixels/pyzm/commit/45210631ee7a01d4b3e25af6dceb90a1a00f2eed))
-- gitignore YOLO .pt weight files ([dc7ac09](https://github.com/pliablepixels/pyzm/commit/dc7ac09dd16a6a4140e7902414e0d957ff5eb0c9))
-- new logo ([764653f](https://github.com/pliablepixels/pyzm/commit/764653f708777fbf63a186a9d21aa2c1fb42f81e))
-- remove balloons animation from training complete ([84077f1](https://github.com/pliablepixels/pyzm/commit/84077f12bd6824ab55149fadb07787f3a8f2562c))
-- consolidate logo, add RTD logo, slim docs dependencies ([4062f09](https://github.com/pliablepixels/pyzm/commit/4062f09afa4190c16a61db5aecf62e350ac5c93f))
-- replace deprecated use_container_width with width ([a57e490](https://github.com/pliablepixels/pyzm/commit/a57e490ce1097b9ca8640d805e63762455fa5c32))
+- switch setup.py to find_packages(), clean up install docs ([4521063](https://github.com/ZoneMinder/pyzmNg/commit/45210631ee7a01d4b3e25af6dceb90a1a00f2eed))
+- gitignore YOLO .pt weight files ([dc7ac09](https://github.com/ZoneMinder/pyzmNg/commit/dc7ac09dd16a6a4140e7902414e0d957ff5eb0c9))
+- new logo ([764653f](https://github.com/ZoneMinder/pyzmNg/commit/764653f708777fbf63a186a9d21aa2c1fb42f81e))
+- remove balloons animation from training complete ([84077f1](https://github.com/ZoneMinder/pyzmNg/commit/84077f12bd6824ab55149fadb07787f3a8f2562c))
+- consolidate logo, add RTD logo, slim docs dependencies ([4062f09](https://github.com/ZoneMinder/pyzmNg/commit/4062f09afa4190c16a61db5aecf62e350ac5c93f))
+- replace deprecated use_container_width with width ([a57e490](https://github.com/ZoneMinder/pyzmNg/commit/a57e490ce1097b9ca8640d805e63762455fa5c32))
 
 ### Refactoring
 
-- remove all pre-v2 legacy code ([3a2633e](https://github.com/pliablepixels/pyzm/commit/3a2633ede1863f6911eb69e54832d8a6bdac5f49))
-- rename ZMClient url= to apiurl=, remove auto-append ([f8acc72](https://github.com/pliablepixels/pyzm/commit/f8acc7210a5a39da34449f28835673ea8a1b5a6e))
-- adaptive upload+label flow based on class types ([24f2a1e](https://github.com/pliablepixels/pyzm/commit/24f2a1eed6758916d1185223ff18f38c7958b724))
-- merge auto-detect into label step, simplify flow ([c77e7e1](https://github.com/pliablepixels/pyzm/commit/c77e7e185164bbabf4286fad3b4509e07da34ef0))
+- remove all pre-v2 legacy code ([3a2633e](https://github.com/ZoneMinder/pyzmNg/commit/3a2633ede1863f6911eb69e54832d8a6bdac5f49))
+- rename ZMClient url= to apiurl=, remove auto-append ([f8acc72](https://github.com/ZoneMinder/pyzmNg/commit/f8acc7210a5a39da34449f28835673ea8a1b5a6e))
+- adaptive upload+label flow based on class types ([24f2a1e](https://github.com/ZoneMinder/pyzmNg/commit/24f2a1eed6758916d1185223ff18f38c7958b724))
+- merge auto-detect into label step, simplify flow ([c77e7e1](https://github.com/ZoneMinder/pyzmNg/commit/c77e7e185164bbabf4286fad3b4509e07da34ef0))
 
 ### revert
 
-- remove label_map remap-only shortcut ([8724836](https://github.com/pliablepixels/pyzm/commit/8724836eae2a393f3dacfeda36904858b7661f0f))
+- remove label_map remap-only shortcut ([8724836](https://github.com/ZoneMinder/pyzmNg/commit/8724836eae2a393f3dacfeda36904858b7661f0f))
 
 ## [2.0.7] - 2026-02-15
 
 ### Documentation
 
-- update CHANGELOG for v2.0.7 ([1566872](https://github.com/pliablepixels/pyzm/commit/1566872faf73e50f7f5e93e43254ccdb7a1d4016))
-- update YOLO model references to match actual disk layout ([599097f](https://github.com/pliablepixels/pyzm/commit/599097fe5cd05e295cf9910efc1e11a66355aa8d))
-- fix incorrect defaults and YAML keys in detection/serve guides ([57710ce](https://github.com/pliablepixels/pyzm/commit/57710cefe29c78ec6ad4da82bd7ed0dae6cff6d9))
+- update CHANGELOG for v2.0.7 ([1566872](https://github.com/ZoneMinder/pyzmNg/commit/1566872faf73e50f7f5e93e43254ccdb7a1d4016))
+- update YOLO model references to match actual disk layout ([599097f](https://github.com/ZoneMinder/pyzmNg/commit/599097fe5cd05e295cf9910efc1e11a66355aa8d))
+- fix incorrect defaults and YAML keys in detection/serve guides ([57710ce](https://github.com/ZoneMinder/pyzmNg/commit/57710cefe29c78ec6ad4da82bd7ed0dae6cff6d9))
 
 ### Miscellaneous
 
-- bump version to v2.0.7 ([a7bf0f3](https://github.com/pliablepixels/pyzm/commit/a7bf0f3a45f8524458fd5d7f665f4dce2f0154be))
+- bump version to v2.0.7 ([a7bf0f3](https://github.com/ZoneMinder/pyzmNg/commit/a7bf0f3a45f8524458fd5d7f665f4dce2f0154be))
 
 ## [2.0.6] - 2026-02-15
 
 ### Bug Fixes
 
-- detect near-zero garbled e2e output in YOLO26 ONNX models ([3e39906](https://github.com/pliablepixels/pyzm/commit/3e39906185c5425c7193cfe6028811aedc307862))
+- detect near-zero garbled e2e output in YOLO26 ONNX models ([3e39906](https://github.com/ZoneMinder/pyzmNg/commit/3e39906185c5425c7193cfe6028811aedc307862))
 
 ### Documentation
 
-- update CHANGELOG for v2.0.6 ([8d7ffa8](https://github.com/pliablepixels/pyzm/commit/8d7ffa8490ab481eb39786b743e240c83693d4f3))
-- clarify that CHANGELOG is not to be touched ([f898ffc](https://github.com/pliablepixels/pyzm/commit/f898ffc02db4dd96f2b07a7d2c506c43320d9104))
-- add per-type overrides section and remove stale "legacy" wording ([a72da12](https://github.com/pliablepixels/pyzm/commit/a72da12b1fb3893e8e8ffcbd6dafc0f4229f8215))
-- add --pyzm-debug to EventStartCommand example ([86a8481](https://github.com/pliablepixels/pyzm/commit/86a84819c5df20e05516a37c66bedc35178b28be))
+- update CHANGELOG for v2.0.6 ([8d7ffa8](https://github.com/ZoneMinder/pyzmNg/commit/8d7ffa8490ab481eb39786b743e240c83693d4f3))
+- clarify that CHANGELOG is not to be touched ([f898ffc](https://github.com/ZoneMinder/pyzmNg/commit/f898ffc02db4dd96f2b07a7d2c506c43320d9104))
+- add per-type overrides section and remove stale "legacy" wording ([a72da12](https://github.com/ZoneMinder/pyzmNg/commit/a72da12b1fb3893e8e8ffcbd6dafc0f4229f8215))
+- add --pyzm-debug to EventStartCommand example ([86a8481](https://github.com/ZoneMinder/pyzmNg/commit/86a84819c5df20e05516a37c66bedc35178b28be))
 
 ### Features
 
-- per-type config overrides and processor logging ([0a41321](https://github.com/pliablepixels/pyzm/commit/0a4132100ddc5e7787fdd150acf54ca09f518e88))
+- per-type config overrides and processor logging ([0a41321](https://github.com/ZoneMinder/pyzmNg/commit/0a4132100ddc5e7787fdd150acf54ca09f518e88))
 
 ### Miscellaneous
 
-- bump version to v2.0.6 ([8973b29](https://github.com/pliablepixels/pyzm/commit/8973b294f7595eb53106c33522289181581b1f59))
-- clarified this is a rewrite ([d045258](https://github.com/pliablepixels/pyzm/commit/d045258516e09929641a286f57c5c4dfa8338125))
+- bump version to v2.0.6 ([8973b29](https://github.com/ZoneMinder/pyzmNg/commit/8973b294f7595eb53106c33522289181581b1f59))
+- clarified this is a rewrite ([d045258](https://github.com/ZoneMinder/pyzmNg/commit/d045258516e09929641a286f57c5c4dfa8338125))
 
 ### Refactoring
 
-- unify logger hierarchy, remove ZMLog and setup_logging ([bb4ca52](https://github.com/pliablepixels/pyzm/commit/bb4ca527b545df04f129e4deb4d59be56de2142a))
+- unify logger hierarchy, remove ZMLog and setup_logging ([bb4ca52](https://github.com/ZoneMinder/pyzmNg/commit/bb4ca527b545df04f129e4deb4d59be56de2142a))
 
 ## [2.0.5] - 2026-02-15
 
 ### Bug Fixes
 
-- add confidence tiebreak and FIRST_NEW strategy ([c0973be](https://github.com/pliablepixels/pyzm/commit/c0973be1d4edf4cab016a4082d20d25bdcaef8c2))
+- add confidence tiebreak and FIRST_NEW strategy ([c0973be](https://github.com/ZoneMinder/pyzmNg/commit/c0973be1d4edf4cab016a4082d20d25bdcaef8c2))
 
 ### Documentation
 
-- update CHANGELOG for v2.0.5 ([677f1a7](https://github.com/pliablepixels/pyzm/commit/677f1a72b908cc90787061d9ad3eb299b0e5a866))
-- update guides for upstream fixes ([1996662](https://github.com/pliablepixels/pyzm/commit/199666217a6366f1bf1a9cf87afe40fe8f77a9a2))
+- update CHANGELOG for v2.0.5 ([677f1a7](https://github.com/ZoneMinder/pyzmNg/commit/677f1a72b908cc90787061d9ad3eb299b0e5a866))
+- update guides for upstream fixes ([1996662](https://github.com/ZoneMinder/pyzmNg/commit/199666217a6366f1bf1a9cf87afe40fe8f77a9a2))
 
 ### Features
 
-- add version bump option when tag already exists ([94bf651](https://github.com/pliablepixels/pyzm/commit/94bf651bf45f310994d00b6b851a7f578f0d6839))
-- add ZM-native logging via setup_zm_logging(), drop SQLAlchemy ([ee6d739](https://github.com/pliablepixels/pyzm/commit/ee6d7394368c836239f864a639616b94cdd28041))
-- add session-level lock interface for EdgeTPU ([4d59d82](https://github.com/pliablepixels/pyzm/commit/4d59d82dfbb6afcd2cf704e4a35571af05aadc7e))
-- support ignore_pattern in zone filtering ([5c66d3f](https://github.com/pliablepixels/pyzm/commit/5c66d3fcf087fecad1eb2981dd2d706f4310e96d))
-- add event_frames() for per-frame metadata ([f52d358](https://github.com/pliablepixels/pyzm/commit/f52d35811a61d06cc99ce417a514d9076d202471))
-- add analysis_fps, bandwidth to MonitorStatus ([607d720](https://github.com/pliablepixels/pyzm/commit/607d72094e261adf8fce5b82290e361456b16bc1))
+- add version bump option when tag already exists ([94bf651](https://github.com/ZoneMinder/pyzmNg/commit/94bf651bf45f310994d00b6b851a7f578f0d6839))
+- add ZM-native logging via setup_zm_logging(), drop SQLAlchemy ([ee6d739](https://github.com/ZoneMinder/pyzmNg/commit/ee6d7394368c836239f864a639616b94cdd28041))
+- add session-level lock interface for EdgeTPU ([4d59d82](https://github.com/ZoneMinder/pyzmNg/commit/4d59d82dfbb6afcd2cf704e4a35571af05aadc7e))
+- support ignore_pattern in zone filtering ([5c66d3f](https://github.com/ZoneMinder/pyzmNg/commit/5c66d3fcf087fecad1eb2981dd2d706f4310e96d))
+- add event_frames() for per-frame metadata ([f52d358](https://github.com/ZoneMinder/pyzmNg/commit/f52d35811a61d06cc99ce417a514d9076d202471))
+- add analysis_fps, bandwidth to MonitorStatus ([607d720](https://github.com/ZoneMinder/pyzmNg/commit/607d72094e261adf8fce5b82290e361456b16bc1))
 
 ### Miscellaneous
 
-- bump version to v2.0.5 ([56003ad](https://github.com/pliablepixels/pyzm/commit/56003ad933f7845ccd1c43174e9ce60be86c0baa))
+- bump version to v2.0.5 ([56003ad](https://github.com/ZoneMinder/pyzmNg/commit/56003ad933f7845ccd1c43174e9ce60be86c0baa))
 
 ## [2.0.4] - 2026-02-14
 
 ### Bug Fixes
 
-- add ZM 1.36.34 SharedData struct layout (768 bytes) ([600768f](https://github.com/pliablepixels/pyzm/commit/600768f6c360cc0649b624116e961d0d7126ee20))
+- add ZM 1.36.34 SharedData struct layout (768 bytes) ([600768f](https://github.com/ZoneMinder/pyzmNg/commit/600768f6c360cc0649b624116e961d0d7126ee20))
 
 ### Documentation
 
-- update CHANGELOG for v2.0.4 ([ab3eb45](https://github.com/pliablepixels/pyzm/commit/ab3eb45165817c57a70d78f4d493986b5cc8ff78))
+- update CHANGELOG for v2.0.4 ([ab3eb45](https://github.com/ZoneMinder/pyzmNg/commit/ab3eb45165817c57a70d78f4d493986b5cc8ff78))
 
 ### Features
 
-- add ZoneMinder live E2E tests and fix events filter bug ([26d1ecd](https://github.com/pliablepixels/pyzm/commit/26d1ecd01b8348ffe266db83254e1ec620374480))
+- add ZoneMinder live E2E tests and fix events filter bug ([26d1ecd](https://github.com/ZoneMinder/pyzmNg/commit/26d1ecd01b8348ffe266db83254e1ec620374480))
 
 ### Miscellaneous
 
-- remove unused make_package.sh ([b6d2218](https://github.com/pliablepixels/pyzm/commit/b6d2218a6181629c438cd1da60bda89117b023ce))
-- ver bump ([b52bc2e](https://github.com/pliablepixels/pyzm/commit/b52bc2e85c2d195f2f9609c713117e2413f95533))
+- remove unused make_package.sh ([b6d2218](https://github.com/ZoneMinder/pyzmNg/commit/b6d2218a6181629c438cd1da60bda89117b023ce))
+- ver bump ([b52bc2e](https://github.com/ZoneMinder/pyzmNg/commit/b52bc2e85c2d195f2f9609c713117e2413f95533))
 
 ## [2.0.3] - 2026-02-14
 
 ### Bug Fixes
 
-- skip commits starting with https in changelog ([8436c5c](https://github.com/pliablepixels/pyzm/commit/8436c5ce08a24df5cf37c8f0e5d91031c1ca37c3))
-- add native YOLO26 end-to-end output parsing with pre-NMS fallback ([575247b](https://github.com/pliablepixels/pyzm/commit/575247b98cfd1c795f4f0fa938a51b37a998ef5f))
-- letterbox preprocessing and xyxy coord format for ONNX YOLO models ([96198d5](https://github.com/pliablepixels/pyzm/commit/96198d5670d042ec6081205f4fe1415883cfe347))
-- eagerly load backends in _ensure_pipeline() for serve ([445b745](https://github.com/pliablepixels/pyzm/commit/445b74507918051291e3c425db7a9a59c3196050))
-- add sphinx_rtd_theme to docs requirements and _static dir ([5ac9bf2](https://github.com/pliablepixels/pyzm/commit/5ac9bf20a7e4f2eb2781b36e024affae15c0b90d))
-- restore pyzm.ml.alpr and pyzm.ml.face in setup.py ([260f666](https://github.com/pliablepixels/pyzm/commit/260f66679db1e2ba96aad68ac47c9e26983d9e9b))
-- handle non-UTF-8 bytes when decoding shared memory strings ([4ba0ee5](https://github.com/pliablepixels/pyzm/commit/4ba0ee502d7a2ab9644b7d869020df32d8eab5c4))
-- don't skip file/console logging when DB reflection fails ([de16b5d](https://github.com/pliablepixels/pyzm/commit/de16b5daed8f34475da74fa039b3669278ce8a89))
-- strip whitespace from stream parameter to handle non-breaking spaces ([3874a26](https://github.com/pliablepixels/pyzm/commit/3874a26fce03d3837062d33949810bf7edf08636))
-- warn when OpenCV version is too old for ONNX YOLOv26 models ([a913280](https://github.com/pliablepixels/pyzm/commit/a913280643d0480bd5a88af5b2ae15eec35cf329))
-- apply defaults for unset env vars and handle missing zm.conf gracefully ([47a8cea](https://github.com/pliablepixels/pyzm/commit/47a8ceaf506a7f08b5da5446bebaab85931329c2))
-- fall back to CPU when CUDA backend is unavailable for YOLO inference ([0223dd1](https://github.com/pliablepixels/pyzm/commit/0223dd1482c3fed0a89da28804bd082fe0c8c3e9))
-- prefix all log messages with model name for clarity ([84e6574](https://github.com/pliablepixels/pyzm/commit/84e6574c4d045466591e296178a8c0d457465121))
-- expose lock_name on wrapper classes for dedup logic ([8db190a](https://github.com/pliablepixels/pyzm/commit/8db190a41d10c69931b95e5efa3fb2f2d59abc5a))
-- prevent deadlock when multiple models share the same GPU lock ([2a84e90](https://github.com/pliablepixels/pyzm/commit/2a84e90531ac60cb2f12f52b3b3ef90758088a35))
-- Later versions of OpenCV have changed format for layers ([271d111](https://github.com/pliablepixels/pyzm/commit/271d111c02b208e53b8cd06aeba60862c2508067))
+- skip commits starting with https in changelog ([8436c5c](https://github.com/ZoneMinder/pyzmNg/commit/8436c5ce08a24df5cf37c8f0e5d91031c1ca37c3))
+- add native YOLO26 end-to-end output parsing with pre-NMS fallback ([575247b](https://github.com/ZoneMinder/pyzmNg/commit/575247b98cfd1c795f4f0fa938a51b37a998ef5f))
+- letterbox preprocessing and xyxy coord format for ONNX YOLO models ([96198d5](https://github.com/ZoneMinder/pyzmNg/commit/96198d5670d042ec6081205f4fe1415883cfe347))
+- eagerly load backends in _ensure_pipeline() for serve ([445b745](https://github.com/ZoneMinder/pyzmNg/commit/445b74507918051291e3c425db7a9a59c3196050))
+- add sphinx_rtd_theme to docs requirements and _static dir ([5ac9bf2](https://github.com/ZoneMinder/pyzmNg/commit/5ac9bf20a7e4f2eb2781b36e024affae15c0b90d))
+- restore pyzm.ml.alpr and pyzm.ml.face in setup.py ([260f666](https://github.com/ZoneMinder/pyzmNg/commit/260f66679db1e2ba96aad68ac47c9e26983d9e9b))
+- handle non-UTF-8 bytes when decoding shared memory strings ([4ba0ee5](https://github.com/ZoneMinder/pyzmNg/commit/4ba0ee502d7a2ab9644b7d869020df32d8eab5c4))
+- don't skip file/console logging when DB reflection fails ([de16b5d](https://github.com/ZoneMinder/pyzmNg/commit/de16b5daed8f34475da74fa039b3669278ce8a89))
+- strip whitespace from stream parameter to handle non-breaking spaces ([3874a26](https://github.com/ZoneMinder/pyzmNg/commit/3874a26fce03d3837062d33949810bf7edf08636))
+- warn when OpenCV version is too old for ONNX YOLOv26 models ([a913280](https://github.com/ZoneMinder/pyzmNg/commit/a913280643d0480bd5a88af5b2ae15eec35cf329))
+- apply defaults for unset env vars and handle missing zm.conf gracefully ([47a8cea](https://github.com/ZoneMinder/pyzmNg/commit/47a8ceaf506a7f08b5da5446bebaab85931329c2))
+- fall back to CPU when CUDA backend is unavailable for YOLO inference ([0223dd1](https://github.com/ZoneMinder/pyzmNg/commit/0223dd1482c3fed0a89da28804bd082fe0c8c3e9))
+- prefix all log messages with model name for clarity ([84e6574](https://github.com/ZoneMinder/pyzmNg/commit/84e6574c4d045466591e296178a8c0d457465121))
+- expose lock_name on wrapper classes for dedup logic ([8db190a](https://github.com/ZoneMinder/pyzmNg/commit/8db190a41d10c69931b95e5efa3fb2f2d59abc5a))
+- prevent deadlock when multiple models share the same GPU lock ([2a84e90](https://github.com/ZoneMinder/pyzmNg/commit/2a84e90531ac60cb2f12f52b3b3ef90758088a35))
+- Later versions of OpenCV have changed format for layers ([271d111](https://github.com/ZoneMinder/pyzmNg/commit/271d111c02b208e53b8cd06aeba60862c2508067))
 
 ### Documentation
 
-- update CHANGELOG for v2.0.3 ([9be2ade](https://github.com/pliablepixels/pyzm/commit/9be2ade821241a9151e1d3f00cbe1544c7caa4c1))
-- update CHANGELOG for v2.0.3 ([8762414](https://github.com/pliablepixels/pyzm/commit/8762414c7c0de2ee63494820728e133fdd7534e5))
-- add developer release notes and --skip-pypi flag ([c726bce](https://github.com/pliablepixels/pyzm/commit/c726bcefdf6b4c40cbe61bc5b04375c1f3b573c7))
-- expand sidebar navigation to show subsection indicators ([09c4948](https://github.com/pliablepixels/pyzm/commit/09c494816440ac0eb531dc751e862b0db5103672))
-- specify OpenCV 4.13+ requirement for ONNX YOLO models ([407422d](https://github.com/pliablepixels/pyzm/commit/407422d73d429ebe962c6cd53053193caa8e9451))
-- link README installation section to RTD guide ([65f67dd](https://github.com/pliablepixels/pyzm/commit/65f67dd563378b7306581aab9f8a3f128fd02c67))
-- add installation guide with --break-system-packages note ([b4f15d9](https://github.com/pliablepixels/pyzm/commit/b4f15d9c13e549b388d4fa928df7af5fb8fb99f2))
-- fix ES link to point to v7+ RTD ([5e095c6](https://github.com/pliablepixels/pyzm/commit/5e095c6e425f0261720b9e20f658cc38bd6aa661))
-- add ES v7+ and zmNg to sidebar ([6bba6e9](https://github.com/pliablepixels/pyzm/commit/6bba6e92c447f745ec686960920a79e8fa33dd97))
-- auto-update copyright year in Sphinx config ([c958458](https://github.com/pliablepixels/pyzm/commit/c95845808b1d8815ced9f2d50520074c6946451f))
-- add related projects section with ES, zmNg, and zmNinja links ([6e9cdc7](https://github.com/pliablepixels/pyzm/commit/6e9cdc7f1fa65728de2e71fab831370d6d6dd87c))
-- add testing guide to README and RTD ([a3706cf](https://github.com/pliablepixels/pyzm/commit/a3706cf039c0d432343c3ed4f63fc5b2bf5fc59b))
-- fix EventStartCommand location in serve.rst ([1577fe2](https://github.com/pliablepixels/pyzm/commit/1577fe22bbc67a85330d8b173e76bb1aee657a4c))
-- point README to pyzmv2.readthedocs.io ([87ecbf1](https://github.com/pliablepixels/pyzm/commit/87ecbf13e2ad2e76ef74b49fce6de12ea6aefbaf))
-- fix ReadTheDocs build for pyzm.serve autodoc ([a6ab684](https://github.com/pliablepixels/pyzm/commit/a6ab684d3ce3b76e18252f89a383cbaa16331d40))
-- clarified never to hit ZM ([6a54eae](https://github.com/pliablepixels/pyzm/commit/6a54eae62b706bc6be96321145547f8097543ce4))
+- update CHANGELOG for v2.0.3 ([9be2ade](https://github.com/ZoneMinder/pyzmNg/commit/9be2ade821241a9151e1d3f00cbe1544c7caa4c1))
+- update CHANGELOG for v2.0.3 ([8762414](https://github.com/ZoneMinder/pyzmNg/commit/8762414c7c0de2ee63494820728e133fdd7534e5))
+- add developer release notes and --skip-pypi flag ([c726bce](https://github.com/ZoneMinder/pyzmNg/commit/c726bcefdf6b4c40cbe61bc5b04375c1f3b573c7))
+- expand sidebar navigation to show subsection indicators ([09c4948](https://github.com/ZoneMinder/pyzmNg/commit/09c494816440ac0eb531dc751e862b0db5103672))
+- specify OpenCV 4.13+ requirement for ONNX YOLO models ([407422d](https://github.com/ZoneMinder/pyzmNg/commit/407422d73d429ebe962c6cd53053193caa8e9451))
+- link README installation section to RTD guide ([65f67dd](https://github.com/ZoneMinder/pyzmNg/commit/65f67dd563378b7306581aab9f8a3f128fd02c67))
+- add installation guide with --break-system-packages note ([b4f15d9](https://github.com/ZoneMinder/pyzmNg/commit/b4f15d9c13e549b388d4fa928df7af5fb8fb99f2))
+- fix ES link to point to v7+ RTD ([5e095c6](https://github.com/ZoneMinder/pyzmNg/commit/5e095c6e425f0261720b9e20f658cc38bd6aa661))
+- add ES v7+ and zmNg to sidebar ([6bba6e9](https://github.com/ZoneMinder/pyzmNg/commit/6bba6e92c447f745ec686960920a79e8fa33dd97))
+- auto-update copyright year in Sphinx config ([c958458](https://github.com/ZoneMinder/pyzmNg/commit/c95845808b1d8815ced9f2d50520074c6946451f))
+- add related projects section with ES, zmNg, and zmNinja links ([6e9cdc7](https://github.com/ZoneMinder/pyzmNg/commit/6e9cdc7f1fa65728de2e71fab831370d6d6dd87c))
+- add testing guide to README and RTD ([a3706cf](https://github.com/ZoneMinder/pyzmNg/commit/a3706cf039c0d432343c3ed4f63fc5b2bf5fc59b))
+- fix EventStartCommand location in serve.rst ([1577fe2](https://github.com/ZoneMinder/pyzmNg/commit/1577fe22bbc67a85330d8b173e76bb1aee657a4c))
+- point README to pyzmv2.readthedocs.io ([87ecbf1](https://github.com/ZoneMinder/pyzmNg/commit/87ecbf13e2ad2e76ef74b49fce6de12ea6aefbaf))
+- fix ReadTheDocs build for pyzm.serve autodoc ([a6ab684](https://github.com/ZoneMinder/pyzmNg/commit/a6ab684d3ce3b76e18252f89a383cbaa16331d40))
+- clarified never to hit ZM ([6a54eae](https://github.com/ZoneMinder/pyzmNg/commit/6a54eae62b706bc6be96321145547f8097543ce4))
 
 ### Features
 
-- add yolo11n, yolo11s, yolo26n, yolo26s model presets ([2843619](https://github.com/pliablepixels/pyzm/commit/2843619436c2b74326c97ef150d5d207a31b9a31))
-- add --models all lazy loading and overhaul serve docs ([4596f63](https://github.com/pliablepixels/pyzm/commit/4596f6339c8e489a41db867e8aed65b75c7af5a8))
-- add URL-mode remote detection for pyzm.serve ([297149d](https://github.com/pliablepixels/pyzm/commit/297149dfaa618dfeb56e729cbe0b64e24e243bd6))
-- add pyzm.serve remote ML detection server and Detector gateway mode ([8ee09bf](https://github.com/pliablepixels/pyzm/commit/8ee09bff22d9e862b1bc21f0f97aabfde3f06ac8))
-- wire up missing config fields and past-detection filtering ([5948937](https://github.com/pliablepixels/pyzm/commit/5948937cdcb9d91dca6cc5c39aa49118972db1fd))
-- add ZMClient.event_path() and fix setup.py module list ([c3e362c](https://github.com/pliablepixels/pyzm/commit/c3e362cd86192d1c1ade24cc27ed4f8a31b51359))
-- pyzm v2 rewrite — Pydantic models, new ML pipeline, ZM API client ([b28a7a0](https://github.com/pliablepixels/pyzm/commit/b28a7a0c86254509829116ecab470a6c8cce200c))
-- add ZM 1.38 SharedData struct support with size-based auto-detection ([7ee4e0b](https://github.com/pliablepixels/pyzm/commit/7ee4e0b55b37b7a57be7b487c8d62aa11ae9b360))
-- add ONNX model support to Yolo class via OpenCV DNN ([8608afe](https://github.com/pliablepixels/pyzm/commit/8608afe49b79a3a3e86c09cfb95d7e68bd9c3032))
+- add yolo11n, yolo11s, yolo26n, yolo26s model presets ([2843619](https://github.com/ZoneMinder/pyzmNg/commit/2843619436c2b74326c97ef150d5d207a31b9a31))
+- add --models all lazy loading and overhaul serve docs ([4596f63](https://github.com/ZoneMinder/pyzmNg/commit/4596f6339c8e489a41db867e8aed65b75c7af5a8))
+- add URL-mode remote detection for pyzm.serve ([297149d](https://github.com/ZoneMinder/pyzmNg/commit/297149dfaa618dfeb56e729cbe0b64e24e243bd6))
+- add pyzm.serve remote ML detection server and Detector gateway mode ([8ee09bf](https://github.com/ZoneMinder/pyzmNg/commit/8ee09bff22d9e862b1bc21f0f97aabfde3f06ac8))
+- wire up missing config fields and past-detection filtering ([5948937](https://github.com/ZoneMinder/pyzmNg/commit/5948937cdcb9d91dca6cc5c39aa49118972db1fd))
+- add ZMClient.event_path() and fix setup.py module list ([c3e362c](https://github.com/ZoneMinder/pyzmNg/commit/c3e362cd86192d1c1ade24cc27ed4f8a31b51359))
+- pyzm v2 rewrite — Pydantic models, new ML pipeline, ZM API client ([b28a7a0](https://github.com/ZoneMinder/pyzmNg/commit/b28a7a0c86254509829116ecab470a6c8cce200c))
+- add ZM 1.38 SharedData struct support with size-based auto-detection ([7ee4e0b](https://github.com/ZoneMinder/pyzmNg/commit/7ee4e0b55b37b7a57be7b487c8d62aa11ae9b360))
+- add ONNX model support to Yolo class via OpenCV DNN ([8608afe](https://github.com/ZoneMinder/pyzmNg/commit/8608afe49b79a3a3e86c09cfb95d7e68bd9c3032))
 
 ### Miscellaneous
 
-- add release tooling (git-cliff + make_release.sh) and fix CLAUDE.md ([1bb0aa9](https://github.com/pliablepixels/pyzm/commit/1bb0aa96c9cb34be73349baded2ecafd5f044025))
-- update package URLs, modernize build, bump to 2.0.1 ([957384a](https://github.com/pliablepixels/pyzm/commit/957384a475ad9f8b9a2d29944bff2e98a70d3e48))
-- bump version to 0.4.1 ([1facaf1](https://github.com/pliablepixels/pyzm/commit/1facaf1dec2cc96facb3d967d8c067c523837d39))
-- bump version to 0.4.0 ([d36120a](https://github.com/pliablepixels/pyzm/commit/d36120a4766a0675ea5f7f9a09ac6e82c9c2da06))
-- CLAUDE.md first version ([7a0e5f8](https://github.com/pliablepixels/pyzm/commit/7a0e5f8f354884a59928d464d7d4982c716b3301))
-- ver bump ([f16a30d](https://github.com/pliablepixels/pyzm/commit/f16a30db13c13fcdea24c787f7a3fe492d2300b8))
+- add release tooling (git-cliff + make_release.sh) and fix CLAUDE.md ([1bb0aa9](https://github.com/ZoneMinder/pyzmNg/commit/1bb0aa96c9cb34be73349baded2ecafd5f044025))
+- update package URLs, modernize build, bump to 2.0.1 ([957384a](https://github.com/ZoneMinder/pyzmNg/commit/957384a475ad9f8b9a2d29944bff2e98a70d3e48))
+- bump version to 0.4.1 ([1facaf1](https://github.com/ZoneMinder/pyzmNg/commit/1facaf1dec2cc96facb3d967d8c067c523837d39))
+- bump version to 0.4.0 ([d36120a](https://github.com/ZoneMinder/pyzmNg/commit/d36120a4766a0675ea5f7f9a09ac6e82c9c2da06))
+- CLAUDE.md first version ([7a0e5f8](https://github.com/ZoneMinder/pyzmNg/commit/7a0e5f8f354884a59928d464d7d4982c716b3301))
+- ver bump ([f16a30d](https://github.com/ZoneMinder/pyzmNg/commit/f16a30db13c13fcdea24c787f7a3fe492d2300b8))
 
 ### Refactoring
 
-- remove model presets, resolve all names from disk ([95e7fe2](https://github.com/pliablepixels/pyzm/commit/95e7fe237a270152dfad947714698d8a256c5bf1))
-- update template_fill to use ${key} syntax instead of legacy {{key}} ([e034833](https://github.com/pliablepixels/pyzm/commit/e03483331d682de48fb2adce7fed850d44b6e796))
-- switch read_config/get from ConfigParser to YAML ([43e9ef7](https://github.com/pliablepixels/pyzm/commit/43e9ef78c55ce8546bdff52744c54b725bd9481a))
-- split Yolo into YoloDarknet and YoloOnnx subclasses ([a8f60ec](https://github.com/pliablepixels/pyzm/commit/a8f60ec57c28925f4b3931848847d326ae30d1a8))
-- remove direct ultralytics backend, use ONNX via OpenCV DNN ([07de62b](https://github.com/pliablepixels/pyzm/commit/07de62b8e33df0c3a630ea2946cad1815d837a00))
+- remove model presets, resolve all names from disk ([95e7fe2](https://github.com/ZoneMinder/pyzmNg/commit/95e7fe237a270152dfad947714698d8a256c5bf1))
+- update template_fill to use ${key} syntax instead of legacy {{key}} ([e034833](https://github.com/ZoneMinder/pyzmNg/commit/e03483331d682de48fb2adce7fed850d44b6e796))
+- switch read_config/get from ConfigParser to YAML ([43e9ef7](https://github.com/ZoneMinder/pyzmNg/commit/43e9ef78c55ce8546bdff52744c54b725bd9481a))
+- split Yolo into YoloDarknet and YoloOnnx subclasses ([a8f60ec](https://github.com/ZoneMinder/pyzmNg/commit/a8f60ec57c28925f4b3931848847d326ae30d1a8))
+- remove direct ultralytics backend, use ONNX via OpenCV DNN ([07de62b](https://github.com/ZoneMinder/pyzmNg/commit/07de62b8e33df0c3a630ea2946cad1815d837a00))
 
 ### Testing
 
-- add 89 e2e tests covering every objectconfig feature ([13b578d](https://github.com/pliablepixels/pyzm/commit/13b578dca4430d15db3ad7a7b0d31b5318bd2147))
+- add 89 e2e tests covering every objectconfig feature ([13b578d](https://github.com/ZoneMinder/pyzmNg/commit/13b578dca4430d15db3ad7a7b0d31b5318bd2147))
 <!-- generated by git-cliff -->

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="logo/pyzm.png" width="200"/>
+<img src="https://raw.githubusercontent.com/ZoneMinder/pyzmNg/master/logo/pyzm.png" width="200"/>
 
 What
 =====

--- a/docs/guide/zm_client.rst
+++ b/docs/guide/zm_client.rst
@@ -62,8 +62,10 @@ Constructor parameters
      - Override the ZM database name
    * - ``conf_path``
      - ``None``
-     - Path to the ZM config directory (default ``/etc/zm``). Useful when
-       ``zm.conf`` lives in a non-standard location.
+     - Path to the ZM config directory. When unset, pyzm honors the
+       ``PYZM_CONFPATH`` env var, then auto-discovers ``zm.conf`` across
+       ``/etc/zm``, ``/config``, and ``/etc/zoneminder``. Set this to force a
+       non-standard location.
    * - ``config``
      - ``None``
      - A pre-built ``ZMClientConfig``. When provided, all other keyword
@@ -86,8 +88,11 @@ Database access
 Some operations — ``ev.tag()``, ``ev.path()``, ``ev.save_objdetect()``
 (when no ``path_override`` is given), and audio extraction for BirdNET —
 require a direct MySQL connection to the ZM database.  By
-default, pyzm reads credentials from ``/etc/zm/zm.conf`` (the same file
-ZoneMinder uses).
+default, pyzm reads credentials from ``zm.conf`` (the same file
+ZoneMinder uses).  It looks for that file first at ``PYZM_CONFPATH`` (if
+the env var is set), then auto-discovers it across ``/etc/zm``,
+``/config`` (common in containerized ZoneMinder), and ``/etc/zoneminder``.
+Pass ``conf_path`` to force a specific directory.
 
 If the user running pyzm cannot read ``zm.conf`` (e.g. permission
 denied), you can pass database credentials explicitly:
@@ -109,9 +114,12 @@ denied), you can pass database credentials explicitly:
 
 The merge strategy is:
 
-1. Try to read ``zm.conf`` (or ``conf_path`` if set).
-2. Overlay any explicit ``db_*`` parameters — explicit values always win.
-3. Fall back to ``"localhost"`` for host and ``"zm"`` for database name.
+1. Resolve the config directory: ``conf_path`` if set, else
+   ``PYZM_CONFPATH``, else the first of ``/etc/zm`` / ``/config`` /
+   ``/etc/zoneminder`` that contains a ``zm.conf``.
+2. Try to read ``zm.conf`` from that directory.
+3. Overlay any explicit ``db_*`` parameters — explicit values always win.
+4. Fall back to ``"localhost"`` for host and ``"zm"`` for database name.
 
 Accessing the full API response
 --------------------------------

--- a/pyzm/__init__.py
+++ b/pyzm/__init__.py
@@ -3,7 +3,7 @@
 v2: Typed configuration, clean APIs, proper result objects.
 """
 
-__version__ = "2.3.6"
+__version__ = "2.3.7"
 VERSION = __version__
 
 from pyzm.client import ZMClient

--- a/pyzm/zm/db.py
+++ b/pyzm/zm/db.py
@@ -1,7 +1,10 @@
 """Direct MySQL connection to the ZoneMinder database.
 
-Reads credentials from ``/etc/zm/zm.conf`` (and ``conf.d/*.conf``) —
-the same files that ZM itself uses.  Explicit overrides take precedence.
+Reads credentials from ``zm.conf`` (and ``conf.d/*.conf``) — the same files
+that ZM itself uses.  The directory is resolved by :func:`_resolve_conf_path`:
+an explicit ``conf_path`` or the ``PYZM_CONFPATH`` env var wins, otherwise a
+few well-known locations are probed (handles containerized ZM, which keeps
+config under ``/config``).  Explicit credential overrides take precedence.
 """
 
 from __future__ import annotations
@@ -14,6 +17,32 @@ import os
 logger = logging.getLogger("pyzm.zm")
 
 _CONF_PATH = os.environ.get("PYZM_CONFPATH", "/etc/zm")
+
+# Well-known directories to probe for zm.conf, in order, when neither an
+# explicit conf_path nor PYZM_CONFPATH is provided. /etc/zm is the default
+# install location; /config is the common container layout; /etc/zoneminder
+# is used by some distro packages.
+_CONF_SEARCH_PATHS = ("/etc/zm", "/config", "/etc/zoneminder")
+
+
+def _resolve_conf_path(conf_path: str | None = None) -> str:
+    """Return the directory to read ZM config from.
+
+    Priority: explicit ``conf_path`` argument, then the ``PYZM_CONFPATH`` env
+    var, then auto-discovery across :data:`_CONF_SEARCH_PATHS` (the first that
+    actually contains a ``zm.conf``). Falls back to ``/etc/zm`` when nothing is
+    found, preserving prior behaviour and its warnings.
+    """
+    if conf_path:
+        return conf_path
+    env = os.environ.get("PYZM_CONFPATH")
+    if env:
+        return env
+    for candidate in _CONF_SEARCH_PATHS:
+        if os.path.exists(os.path.join(candidate, "zm.conf")):
+            logger.debug("Auto-discovered ZM config at %s", candidate)
+            return candidate
+    return _CONF_SEARCH_PATHS[0]
 
 
 def _read_zm_conf(conf_path: str = _CONF_PATH) -> dict[str, str]:
@@ -62,7 +91,7 @@ def get_zm_db(
     # Start with zm.conf values (best-effort)
     has_explicit = any(v is not None for v in [db_user, db_password, db_host, db_name])
     try:
-        creds = _read_zm_conf(conf_path or _CONF_PATH)
+        creds = _read_zm_conf(_resolve_conf_path(conf_path))
     except (PermissionError, OSError) as exc:
         if has_explicit:
             logger.debug("Could not read zm.conf: %s (using explicit credentials)", exc)

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,0 +1,38 @@
+"""Tests for README.md packaging correctness.
+
+README.md is shipped verbatim as the PyPI ``long_description`` (see setup.py).
+PyPI cannot resolve relative image paths, so every image ``src`` must be an
+absolute URL or the logo/images render broken on the project page.
+
+See https://github.com/ZoneMinder/pyzmNg/issues/49
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+README = Path(__file__).resolve().parent.parent / "README.md"
+
+# Matches src="..." in <img> tags and ![alt](...) markdown images.
+_HTML_IMG_SRC = re.compile(r"<img\b[^>]*?\bsrc=[\"']([^\"']+)[\"']", re.IGNORECASE)
+_MD_IMG_SRC = re.compile(r"!\[[^\]]*\]\(([^)\s]+)")
+
+
+def _image_srcs() -> list[str]:
+    text = README.read_text(encoding="utf-8")
+    return _HTML_IMG_SRC.findall(text) + _MD_IMG_SRC.findall(text)
+
+
+def test_readme_exists():
+    assert README.is_file()
+
+
+def test_all_readme_images_are_absolute_urls():
+    """Relative image paths render broken on PyPI; require absolute URLs."""
+    srcs = _image_srcs()
+    assert srcs, "expected at least one image in README.md"
+    relative = [s for s in srcs if not s.startswith(("http://", "https://"))]
+    assert not relative, (
+        f"README image src(s) must be absolute URLs for PyPI: {relative}"
+    )

--- a/tests/test_zm/test_db.py
+++ b/tests/test_zm/test_db.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from pyzm.zm.db import _read_zm_conf, get_zm_db
+from pyzm.zm.db import _read_zm_conf, _resolve_conf_path, get_zm_db
 
 
 class TestReadZmConf:
@@ -244,3 +244,59 @@ class TestClientGetDb:
             db_name=None,
             conf_path=None,
         )
+
+
+class TestResolveConfPath:
+    """Tests for _resolve_conf_path() priority and auto-discovery (issue #54)."""
+
+    def test_explicit_conf_path_wins(self, monkeypatch):
+        """An explicit conf_path beats PYZM_CONFPATH and discovery."""
+        monkeypatch.setenv("PYZM_CONFPATH", "/env/path")
+        assert _resolve_conf_path("/explicit") == "/explicit"
+
+    def test_env_var_wins_over_discovery(self, monkeypatch):
+        """PYZM_CONFPATH is used when no explicit conf_path is given."""
+        monkeypatch.setenv("PYZM_CONFPATH", "/env/path")
+        assert _resolve_conf_path() == "/env/path"
+
+    def test_autodiscovers_first_dir_with_zm_conf(self, monkeypatch, tmp_path):
+        """Discovery returns the first search path that contains a zm.conf."""
+        monkeypatch.delenv("PYZM_CONFPATH", raising=False)
+        empty = tmp_path / "empty"
+        has_conf = tmp_path / "config"
+        empty.mkdir()
+        has_conf.mkdir()
+        (has_conf / "zm.conf").write_text("ZM_DB_NAME=zm\n")
+        monkeypatch.setattr(
+            "pyzm.zm.db._CONF_SEARCH_PATHS", (str(empty), str(has_conf))
+        )
+        assert _resolve_conf_path() == str(has_conf)
+
+    def test_falls_back_to_first_path_when_none_found(self, monkeypatch, tmp_path):
+        """With no zm.conf anywhere, fall back to the first search path."""
+        monkeypatch.delenv("PYZM_CONFPATH", raising=False)
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        monkeypatch.setattr("pyzm.zm.db._CONF_SEARCH_PATHS", (str(a), str(b)))
+        assert _resolve_conf_path() == str(a)
+
+    @patch("mysql.connector.connect")
+    def test_get_zm_db_autodiscovers_conf(self, mock_connect, monkeypatch, tmp_path):
+        """get_zm_db reads creds from a discovered zm.conf when no path given."""
+        monkeypatch.delenv("PYZM_CONFPATH", raising=False)
+        confdir = tmp_path / "config"
+        confdir.mkdir()
+        (confdir / "zm.conf").write_text(
+            "ZM_DB_USER=disc_user\nZM_DB_PASS=p\nZM_DB_HOST=disc_host\nZM_DB_NAME=d\n"
+        )
+        monkeypatch.setattr(
+            "pyzm.zm.db._CONF_SEARCH_PATHS", (str(tmp_path / "none"), str(confdir))
+        )
+
+        get_zm_db()
+
+        call_kwargs = mock_connect.call_args[1]
+        assert call_kwargs["user"] == "disc_user"
+        assert call_kwargs["host"] == "disc_host"


### PR DESCRIPTION
## Summary

`get_zm_db()` defaulted its config search to `/etc/zm`, overridable only via `conf_path` or `PYZM_CONFPATH`. Containerized ZoneMinder keeps `zm.conf` at `/config` (and some distro packages use `/etc/zoneminder`), so pyzm silently fell back to `host=localhost` and DB access failed:

```
WAR [db.py:117] [DB connect to localhost:3306 failed: 2003 (HY000): Can't connect to MySQL server on 'localhost:3306' (111)]
```

## Change

New `_resolve_conf_path()` with priority:

1. explicit `conf_path` argument (unchanged, highest priority)
2. `PYZM_CONFPATH` env var (unchanged)
3. auto-discovery across `/etc/zm`, `/config`, `/etc/zoneminder` — first dir containing a `zm.conf` wins
4. fall back to `/etc/zm` when nothing is found (preserves current behaviour/warnings)

All existing override paths are preserved. `get_zm_db()` now routes through the resolver.

## Tests

- New `TestResolveConfPath` (explicit wins, env wins, discovery picks first-with-`zm.conf`, fallback, end-to-end `get_zm_db` discovery).
- `tests/test_zm/` + `tests/test_config_variants.py`: **244 passed**.

## Docs

Updated `docs/guide/zm_client.rst` (`conf_path` row, Database-access section, merge-strategy list).

Fixes #54. Pairs with downstream ZoneMinder/zmeventnotificationNg#32 (exposes a `zm_conf_path` key that flows into `ZMClient(conf_path=...)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)