### PR TITLE
fix(api): return None on 404 for JSON endpoints instead of BAD_IMAGE

### DIFF
--- a/pyzm/zm/api.py
+++ b/pyzm/zm/api.py
@@ -271,6 +271,13 @@ class ZMAPI:
             return self.request(url, method, params, payload, reauth=False)
 
         if status == 404:
+            # A 404 on a JSON API endpoint means the resource does not exist.
+            # Return None so the caller can raise its own descriptive error
+            # (e.g. "Event 5 not found").  Only image/frame fetches map to
+            # BAD_IMAGE (relied on by media.py and zm_detect.py).
+            if url.split("?", 1)[0].endswith(".json"):
+                logger.debug("Got 404 on JSON endpoint; returning None")
+                return None
             logger.debug("Got 404; raising BAD_IMAGE")
             raise ValueError("BAD_IMAGE")
 

--- a/tests/test_ml_e2e/conftest.py
+++ b/tests/test_ml_e2e/conftest.py
@@ -25,7 +25,13 @@ import pytest
 # ---------------------------------------------------------------------------
 
 BIRD_IMAGE = str(Path(__file__).parent / "bird.jpg")
-BASE_PATH = "/var/lib/zmeventnotification/models"
+BASE_PATH = os.environ.get(
+    "PYZM_E2E_MODELS", "/var/lib/zmeventnotification/models"
+)
+# Repo root (…/tests/test_ml_e2e/conftest.py -> parents[2]); used as the cwd
+# and PYTHONPATH for the server subprocess so the working-tree copy of pyzm
+# is authoritative regardless of where the repo is checked out.
+REPO_ROOT = str(Path(__file__).resolve().parents[2])
 
 
 # ---------------------------------------------------------------------------
@@ -99,8 +105,8 @@ def start_serve(models, port, extra_args=None):
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        cwd="/home/arjunrc/fiddle/pyzm",
-        env={**os.environ, "PYTHONPATH": "/home/arjunrc/fiddle/pyzm"},
+        cwd=REPO_ROOT,
+        env={**os.environ, "PYTHONPATH": REPO_ROOT},
     )
 
 

--- a/tests/test_zm/test_api.py
+++ b/tests/test_zm/test_api.py
@@ -281,6 +281,21 @@ class TestZMAPIRequest:
         with pytest.raises(ValueError, match="BAD_IMAGE"):
             api.request("https://zm.example.com/zm/index.php?view=image&eid=1")
 
+    def test_404_on_json_endpoint_returns_none(self):
+        """A 404 on a .json API endpoint returns None (not BAD_IMAGE), so
+        callers can raise their own descriptive 'not found' error."""
+        api, session, auth = self._make_api()
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        http_error = requests.HTTPError(response=mock_resp)
+        mock_resp.raise_for_status.side_effect = http_error
+        session.get.return_value = mock_resp
+
+        # query params after .json must not defeat the check
+        result = api.request("https://zm.example.com/zm/api/events/5.json?token=x")
+        assert result is None
+
     def test_bad_image_zero_content_length(self):
         api, session, auth = self._make_api()
 

--- a/tests/test_zm/test_client.py
+++ b/tests/test_zm/test_client.py
@@ -1163,6 +1163,20 @@ class TestZMClientEvents:
         with pytest.raises(ValueError, match="not found"):
             client.event(99999)
 
+    @patch("pyzm.client.ZMAPI")
+    def test_event_404_returns_none_raises_not_found(self, mock_zmapi_cls):
+        """A 404 (api.get returns None, e.g. a deleted event) surfaces as a
+        descriptive 'not found', not BAD_IMAGE. Regression for #56."""
+        mock_api = _make_mock_api()
+        mock_api.get.return_value = None
+        mock_zmapi_cls.return_value = mock_api
+
+        from pyzm.client import ZMClient
+        client = ZMClient(api_url="https://zm.example.com/zm/api")
+
+        with pytest.raises(ValueError, match="not found"):
+            client.event(233090)
+
 
 # ===================================================================
 # TestEvent - OOP methods


### PR DESCRIPTION
Fixes #56.

## Problem
`ZMApi._handle_http_error` mapped **every** HTTP 404 to `ValueError("BAD_IMAGE")`. That's correct for image/frame fetches (`media.py`, and zmeventnotification's `zm_detect.py`) but wrong for JSON API endpoints — it made the descriptive `"<resource> not found"` errors in `client.py` (`event()`, `monitor()`, `notification()`, …) unreachable, and surfaced a confusing `BAD_IMAGE` when looking up a missing/deleted resource.

## Fix
A 404 on a `.json` endpoint now returns `None`, so the caller raises its own descriptive "not found". Image fetches still raise `BAD_IMAGE` (URLs aren't `.json`), preserving `media.py` / `zm_detect.py` behavior.

```python
if status == 404:
    if url.split("?", 1)[0].endswith(".json"):
        return None            # caller raises "<resource> not found"
    raise ValueError("BAD_IMAGE")
```

## How it surfaced
The live write-tier e2e test `tests/test_zm_e2e/test_write_events.py::test_delete_event` deleted an event, then `client.event(id)` returned `BAD_IMAGE` instead of "not found". After the fix it passes against a live ZM 1.39.1 server.

## Tests
- `test_api.py::test_404_on_json_endpoint_returns_none` — 404 on `.json` (with query params) returns `None`; existing image-404 → `BAD_IMAGE` test still passes.
- `test_client.py::test_event_404_returns_none_raises_not_found` — regression for #56.
- Full unit/integration suite: 1052 passed.

Unrelated to #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)