### PR TITLE
test: robustness fixes — contract, notifications, serve filters, best-frame (TDD)

### DIFF
--- a/tests/test_ml/test_detector.py
+++ b/tests/test_ml/test_detector.py
@@ -1869,3 +1869,51 @@ class TestDetectEventFrameSelection:
         det = self._make_detector()
         det._config.frame_strategy = FrameStrategy.MOST_MODELS
         assert self._forwarded_stop_on_match(mock_requests, det, self._make_zm_client()) is False
+
+
+class TestRemoteBestFrameSelection:
+    """`_remote_detect_urls` must pick the best frame across multiple gateway
+    frames for the most*/best strategies -- not just forward a flag."""
+
+    def _make_detector(self, strategy):
+        from pyzm.ml.detector import Detector
+        det = Detector.__new__(Detector)
+        det._config = DetectorConfig(pattern=".*")
+        det._config.frame_strategy = strategy
+        det._pipeline = None
+        det._gateway = "http://gpu:5000"
+        det._gateway_mode = "url"
+        det._gateway_token = None
+        det._gateway_timeout = 10
+        det._gateway_username = None
+        det._gateway_password = None
+        return det
+
+    @staticmethod
+    def _frame(fid, labels):
+        from pyzm.models.detection import BBox, Detection, DetectionResult
+        dets = [Detection(l, 0.9, BBox(0, 0, 10, 10), "yolov4") for l in labels]
+        return DetectionResult(
+            detections=dets, frame_id=fid,
+            image_dimensions={"original": (100, 100)},
+        ).to_dict()
+
+    @patch("pyzm.ml.detector.requests")
+    def test_most_strategy_returns_richest_frame(self, mock_requests):
+        from pyzm.models.config import FrameStrategy
+        det = self._make_detector(FrameStrategy.MOST)
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"results": [
+            self._frame("1", ["person"]),
+            self._frame("2", ["person", "dog", "cat"]),   # richest
+            self._frame("3", ["person", "dog"]),
+        ]}
+        mock_resp.raise_for_status = MagicMock()
+        mock_requests.post.return_value = mock_resp
+
+        frame_urls = [{"frame_id": str(i), "url": f"http://zm/i?fid={i}"} for i in (1, 2, 3)]
+        result = det._remote_detect_urls(frame_urls, zm_auth="", zones=None)
+
+        assert result.frame_id == "2"
+        assert len(result.detections) == 3

--- a/tests/test_models/test_wire_contract.py
+++ b/tests/test_models/test_wire_contract.py
@@ -1,0 +1,82 @@
+"""Wire-format contract for DetectionResult.to_dict()/from_dict().
+
+This is the exact dict shape that crosses the pyzm <-> zmeventnotification (ES)
+boundary: the ML gateway serialises a DetectionResult with ``to_dict()`` and the
+client rebuilds it with ``from_dict()``; ES's ``format_detection_output`` and
+``zm_detect`` read these keys directly by name.
+
+A silent rename/removal of any key here is a production KeyError in ES with the
+rest of the suite green. These tests lock the contract with real objects (no
+mocks) so such a change fails loudly and on purpose.
+"""
+
+from __future__ import annotations
+
+from pyzm.models.detection import BBox, Detection, DetectionResult
+
+
+# The frozen wire contract. If you change this set you are changing what ES
+# consumes -- update ES (hook/zmes_hook_helpers/utils.py, zm_detect.py) in the
+# same change and update this test deliberately.
+WIRE_KEYS = {
+    "boxes",
+    "labels",
+    "confidences",
+    "frame_id",
+    "image_dimensions",
+    "image",
+    "error_boxes",
+    "model_names",
+    "detection_types",
+    "polygons",
+}
+
+
+def _sample_result() -> DetectionResult:
+    return DetectionResult(
+        detections=[
+            Detection("person", 0.91, BBox(10, 20, 110, 220), model_name="yolov4", detection_type="object"),
+            Detection("dog", 0.63, BBox(300, 40, 360, 120), model_name="yolov4", detection_type="object"),
+        ],
+        frame_id="snapshot",
+        image_dimensions={"original": (600, 800)},
+        error_boxes=[BBox(5, 5, 15, 15)],
+    )
+
+
+def test_to_dict_key_set_is_exactly_the_wire_contract():
+    """to_dict() must emit exactly the keys ES reads -- no more, no less."""
+    keys = set(_sample_result().to_dict().keys())
+    assert keys == WIRE_KEYS, (
+        f"wire contract drift: missing={WIRE_KEYS - keys}, extra={keys - WIRE_KEYS}"
+    )
+
+
+def test_empty_result_still_emits_full_wire_contract():
+    """Even with no detections, every key ES reads must be present."""
+    assert set(DetectionResult().to_dict().keys()) == WIRE_KEYS
+
+
+def test_round_trip_preserves_detections():
+    """from_dict(to_dict(r)) reconstructs the detection payload faithfully."""
+    original = _sample_result()
+    rebuilt = DetectionResult.from_dict(original.to_dict())
+
+    assert rebuilt.labels == ["person", "dog"]
+    assert rebuilt.confidences == [0.91, 0.63]
+    assert rebuilt.boxes == [[10, 20, 110, 220], [300, 40, 360, 120]]
+    assert [d.model_name for d in rebuilt.detections] == ["yolov4", "yolov4"]
+    assert [d.detection_type for d in rebuilt.detections] == ["object", "object"]
+    assert rebuilt.frame_id == "snapshot"
+    assert rebuilt.image_dimensions == {"original": (600, 800)}
+    assert [eb.as_list() for eb in rebuilt.error_boxes] == [[5, 5, 15, 15]]
+
+
+def test_to_dict_values_align_by_index():
+    """labels/boxes/confidences/model_names stay index-aligned (ES zips them)."""
+    d = _sample_result().to_dict()
+    n = len(d["labels"])
+    assert len(d["boxes"]) == n
+    assert len(d["confidences"]) == n
+    assert len(d["model_names"]) == n
+    assert len(d["detection_types"]) == n

--- a/tests/test_models/test_zm.py
+++ b/tests/test_models/test_zm.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
 
-from pyzm.models.zm import Event, Frame, Monitor, MonitorStatus, PTZCapabilities, Zone
+from pyzm.models.zm import (
+    Event,
+    Frame,
+    Monitor,
+    MonitorStatus,
+    Notification,
+    PTZCapabilities,
+    Zone,
+)
 
 
 # ===================================================================
@@ -485,3 +493,83 @@ class TestRaw:
         m1 = Monitor(id=1, name="Test", _raw={"Monitor": {"Id": "1"}})
         m2 = Monitor(id=1, name="Test", _raw={"different": "data"})
         assert m1 == m2
+
+
+# ===================================================================
+# TestNotification -- push-token registration logic
+# ===================================================================
+
+class TestNotification:
+    """Real logic for should_notify / is_throttled / monitors parsing.
+
+    These drive whether a push token actually fires in production; before
+    these tests the whole subsystem had zero coverage.
+    """
+
+    # -- monitors() -----------------------------------------------------
+
+    def test_monitors_none_when_list_empty(self):
+        assert Notification(id=1, monitor_list=None).monitors() is None
+        assert Notification(id=1, monitor_list="").monitors() is None
+
+    def test_monitors_parses_csv_to_ints(self):
+        assert Notification(id=1, monitor_list="1,2,7").monitors() == [1, 2, 7]
+
+    def test_monitors_tolerates_whitespace_and_blanks(self):
+        assert Notification(id=1, monitor_list=" 3 , ,5 ").monitors() == [3, 5]
+
+    # -- should_notify() ------------------------------------------------
+
+    def test_should_notify_false_when_not_enabled(self):
+        n = Notification(id=1, push_state="disabled", monitor_list=None)
+        assert n.should_notify(2) is False
+
+    def test_should_notify_true_for_all_monitors_when_list_empty(self):
+        n = Notification(id=1, push_state="enabled", monitor_list=None)
+        assert n.should_notify(999) is True
+
+    def test_should_notify_respects_monitor_membership(self):
+        n = Notification(id=1, push_state="enabled", monitor_list="2,5")
+        assert n.should_notify(2) is True
+        assert n.should_notify(3) is False
+
+    # -- is_throttled() -------------------------------------------------
+
+    def test_not_throttled_when_interval_zero(self):
+        n = Notification(id=1, interval=0, last_notified_at=datetime.now())
+        assert n.is_throttled() is False
+
+    def test_not_throttled_when_never_sent(self):
+        n = Notification(id=1, interval=600, last_notified_at=None)
+        assert n.is_throttled() is False
+
+    def test_throttled_within_interval(self):
+        # sent 100s ago, interval 1000s -> still throttled
+        n = Notification(
+            id=1, interval=1000,
+            last_notified_at=datetime.now() - timedelta(seconds=100),
+        )
+        assert n.is_throttled() is True
+
+    def test_not_throttled_after_interval(self):
+        # sent 100s ago, interval 10s -> interval elapsed, not throttled
+        n = Notification(
+            id=1, interval=10,
+            last_notified_at=datetime.now() - timedelta(seconds=100),
+        )
+        assert n.is_throttled() is False
+
+    # -- from_api_dict() ------------------------------------------------
+
+    def test_from_api_dict_parses_fields(self):
+        n = Notification.from_api_dict({"Notification": {
+            "Id": "7", "UserId": "3", "Token": "abc", "Platform": "ios",
+            "MonitorList": "1,2", "Interval": "300", "PushState": "enabled",
+            "BadgeCount": "4",
+        }})
+        assert n.id == 7
+        assert n.user_id == 3
+        assert n.token == "abc"
+        assert n.monitors() == [1, 2]
+        assert n.interval == 300
+        assert n.badge_count == 4

--- a/tests/test_serve/test_app.py
+++ b/tests/test_serve/test_app.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -406,3 +406,75 @@ class TestDetectUrls:
         # All detections should be filtered out
         for r in results:
             assert not r.get("labels")
+
+    @pytest.mark.integration
+    @patch("pyzm.serve.app.http_requests")
+    def test_detect_urls_pattern_filter_drops_nonmatching(self, mock_http, client):
+        """Server-side pattern filter drops labels not matching the client regex."""
+        jpeg_bytes = self._make_jpeg_bytes()
+        ok_resp = MagicMock()
+        ok_resp.content = jpeg_bytes
+        ok_resp.status_code = 200
+        ok_resp.raise_for_status = MagicMock()
+        mock_http.get.return_value = ok_resp
+
+        payload = {
+            "urls": [{"frame_id": "1", "url": "http://zm/image?fid=1"}],
+            "pattern": "(car)",  # mock detector returns 'person' -> must be dropped
+            "stop_on_match": False,
+        }
+        resp = client.post("/detect_urls", json=payload)
+        assert resp.status_code == 200
+        assert resp.json()["results"][0]["labels"] == []
+
+    @pytest.mark.integration
+    @patch("pyzm.serve.app.http_requests")
+    def test_detect_urls_pattern_filter_keeps_matching(self, mock_http, client):
+        """A matching pattern keeps the detection (guards against over-filtering)."""
+        jpeg_bytes = self._make_jpeg_bytes()
+        ok_resp = MagicMock()
+        ok_resp.content = jpeg_bytes
+        ok_resp.status_code = 200
+        ok_resp.raise_for_status = MagicMock()
+        mock_http.get.return_value = ok_resp
+
+        payload = {
+            "urls": [{"frame_id": "1", "url": "http://zm/image?fid=1"}],
+            "pattern": "(person)",
+            "stop_on_match": False,
+        }
+        resp = client.post("/detect_urls", json=payload)
+        assert resp.json()["results"][0]["labels"] == ["person"]
+
+    @pytest.mark.integration
+    @patch("pyzm.serve.app.asyncio.sleep", new_callable=AsyncMock)
+    @patch("pyzm.serve.app.http_requests")
+    def test_detect_urls_retries_404_then_succeeds(self, mock_http, mock_sleep, client):
+        """A frame that 404s then appears on retry is fetched and analyzed.
+
+        Exercises the max_attempts>1 branch (dead code under the existing
+        tests, which all use max_attempts=1): the retry loop, the sleep, and
+        the resp=resp2 reassignment.
+        """
+        jpeg_bytes = self._make_jpeg_bytes()
+        not_found = MagicMock()
+        not_found.status_code = 404
+        ok_resp = MagicMock()
+        ok_resp.content = jpeg_bytes
+        ok_resp.status_code = 200
+        ok_resp.raise_for_status = MagicMock()
+        # initial 404, retry #2 404, retry #3 succeeds
+        mock_http.get.side_effect = [not_found, not_found, ok_resp]
+
+        payload = {
+            "urls": [{"frame_id": "5", "url": "http://zm/image?fid=5"}],
+            "max_attempts": 3,
+            "sleep_between_attempts": 0,
+            "stop_on_match": False,
+        }
+        resp = client.post("/detect_urls", json=payload)
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        assert mock_http.get.call_count == 3          # initial + 2 retries
+        assert mock_sleep.await_count == 2            # slept before each retry
+        assert results and results[0]["labels"] == ["person"]  # retried frame analyzed

--- a/tests/test_serve/test_app.py
+++ b/tests/test_serve/test_app.py
@@ -15,22 +15,32 @@ from pyzm.models.detection import BBox, Detection, DetectionResult
 # ---------------------------------------------------------------------------
 
 def _mock_detector():
-    """Return a mock Detector whose detect() returns a canned result."""
+    """Return a mock Detector whose detect() returns a canned result.
+
+    detect() uses side_effect (not return_value) so every call gets a FRESH
+    DetectionResult. The server mutates result.detections in place (confidence
+    and pattern filters); a shared return_value would leak those mutations
+    across frames within a single request, unlike the real Detector.
+    """
     det = MagicMock()
     det._pipeline = True  # so /health reports models_loaded=True
     det._config = MagicMock()
     det._config.models = [MagicMock()]
-    det.detect.return_value = DetectionResult(
-        detections=[
-            Detection(
-                label="person",
-                confidence=0.95,
-                bbox=BBox(10, 20, 50, 80),
-                model_name="yolov4",
-            )
-        ],
-        frame_id="single",
-    )
+
+    def _fresh_result(*_args, **_kwargs):
+        return DetectionResult(
+            detections=[
+                Detection(
+                    label="person",
+                    confidence=0.95,
+                    bbox=BBox(10, 20, 50, 80),
+                    model_name="yolov4",
+                )
+            ],
+            frame_id="single",
+        )
+
+    det.detect.side_effect = _fresh_result
     return det
 
 

--- a/tests/test_zm/test_client.py
+++ b/tests/test_zm/test_client.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from pyzm.models.config import StreamConfig, ZMClientConfig
-from pyzm.models.zm import Event, Monitor, PTZCapabilities, Zone
+from pyzm.models.zm import Event, Monitor, Notification, PTZCapabilities, Zone
 
 
 # ===================================================================
@@ -2130,3 +2130,90 @@ class TestZMClientServersStorage:
         client = ZMClient(api_url="https://zm.example.com/zm/api")
 
         assert client.storage() == []
+
+
+# ===================================================================
+# TestZMClientNotifications -- the untested notification getters
+# ===================================================================
+
+class TestZMClientNotifications:
+    @patch("pyzm.client.ZMAPI")
+    def test_notifications_returns_bound_objects(self, mock_zmapi_cls):
+        mock_api = _make_mock_api()
+        mock_api.get.return_value = {"notifications": [
+            {"Notification": {"Id": "1", "Token": "a", "MonitorList": "2"}},
+            {"Notification": {"Id": "2", "Token": "b"}},
+        ]}
+        mock_zmapi_cls.return_value = mock_api
+
+        from pyzm.client import ZMClient
+        client = ZMClient(api_url="https://zm.example.com/zm/api")
+        notifs = client.notifications()
+
+        mock_api.get.assert_called_with("notifications.json")
+        assert [n.id for n in notifs] == [1, 2]
+        assert all(isinstance(n, Notification) for n in notifs)
+        assert notifs[0]._client is client  # bound so .delete()/.update work
+
+    @patch("pyzm.client.ZMAPI")
+    def test_notifications_empty(self, mock_zmapi_cls):
+        mock_api = _make_mock_api()
+        mock_api.get.return_value = {"notifications": []}
+        mock_zmapi_cls.return_value = mock_api
+
+        from pyzm.client import ZMClient
+        client = ZMClient(api_url="https://zm.example.com/zm/api")
+        assert client.notifications() == []
+
+    @patch("pyzm.client.ZMAPI")
+    def test_notification_by_id(self, mock_zmapi_cls):
+        mock_api = _make_mock_api()
+        mock_api.get.return_value = {"notification": {"Id": "7", "Token": "abc"}}
+        mock_zmapi_cls.return_value = mock_api
+
+        from pyzm.client import ZMClient
+        client = ZMClient(api_url="https://zm.example.com/zm/api")
+        n = client.notification(7)
+        mock_api.get.assert_called_with("notifications/7.json")
+        assert n.id == 7
+
+
+# ===================================================================
+# TestNotFoundNonePath -- single-resource getters must raise "not found"
+# on a 404 (api.get returns None post-#56), not only on an empty {} body.
+# ===================================================================
+
+class TestNotFoundNonePath:
+    def _client(self, mock_zmapi_cls, get):
+        mock_api = _make_mock_api()
+        mock_api.get.side_effect = get if isinstance(get, list) else None
+        if not isinstance(get, list):
+            mock_api.get.return_value = get
+        mock_zmapi_cls.return_value = mock_api
+        from pyzm.client import ZMClient
+        return ZMClient(api_url="https://zm.example.com/zm/api")
+
+    @patch("pyzm.client.ZMAPI")
+    def test_notification_none_raises_not_found(self, mock_zmapi_cls):
+        client = self._client(mock_zmapi_cls, None)
+        with pytest.raises(ValueError, match="not found"):
+            client.notification(999)
+
+    @patch("pyzm.client.ZMAPI")
+    def test_monitor_none_raises_not_found(self, mock_zmapi_cls):
+        # monitors() list empty, then direct lookup 404 -> None
+        client = self._client(mock_zmapi_cls, [{"monitors": []}, None])
+        with pytest.raises(ValueError, match="not found"):
+            client.monitor(999)
+
+    @patch("pyzm.client.ZMAPI")
+    def test_config_none_raises_not_found(self, mock_zmapi_cls):
+        client = self._client(mock_zmapi_cls, None)
+        with pytest.raises(ValueError, match="not found"):
+            client.config("NONEXISTENT")
+
+    @patch("pyzm.client.ZMAPI")
+    def test_control_none_raises_not_found(self, mock_zmapi_cls):
+        client = self._client(mock_zmapi_cls, None)
+        with pytest.raises(ValueError, match="not found"):
+            client._ptz_capabilities(999)


### PR DESCRIPTION
refs #60. Test-robustness hardening from the audit. Every test was verified to **fail against the specific mutation** the audit named (proper TDD for characterization tests), then pass on correct code. +26 tests; Tier-1 now 1159 passed.

## What's covered
- **Wire contract** (`test_wire_contract.py`): `DetectionResult.to_dict()` exact key-set + `from_dict` round-trip — the pyzm↔ES boundary. Fails if `confidences`→`confidence` (the ES-breaking rename).
- **Notification subsystem** (`test_zm.py`): `should_notify`/`is_throttled`/`monitors()` — real throttle math. Fails when the `is_throttled` comparison is flipped.
- **Client notification getters + #56 None-path** (`test_client.py`): `notifications()`/`notification()`; and `monitor()/config()/control()/notification()` must raise "not found" on `None` (404), not only `{}`. Fails when a guard crashes on `None`.
- **Serve pattern filter + 404-retry** (`test_app.py`): both had zero coverage. Retry test fails if `resp=resp2` is dropped (late live-event frames ignored).
- **Best-frame selection** (`test_detector.py`): `_remote_detect_urls` picks the richest frame for MOST. Fails if `_is_better` args are swapped.
- **Mock fidelity**: serve mock returns a fresh `DetectionResult` per call (server mutates in place).

## Verified
- `pytest -m "not e2e and not zm_e2e and not serve"` → 1159 passed.
- Each teeth-check mutation reproduced then reverted (shown in commit messages).

## Remaining (follow-up, tracked in #60)
- Tautological e2e assertions in `tests/test_ml_e2e/` (`assert isinstance(..., list)`, `if result.matched:` guards) — need model-ground-truth to harden safely; deferred to a models-on-box pass.
- Minor branches: sparse-sampling zero-defaults, `detector_config` multi-worker round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)