### PR TITLE
fix(media): don't let a frame-fetch timeout abort the event

### DIFF
--- a/docs/guide/detection.rst
+++ b/docs/guide/detection.rst
@@ -481,6 +481,13 @@ times and then skipped; extraction stops once
 extracted are still returned and detection runs on them, so one
 unreachable frame does not abort the event.
 
+An unreachable ZM therefore stalls extraction rather than failing it
+outright. The worst case is ``contig_frames_before_error`` ×
+``max_attempts`` × (``ZMClientConfig.timeout`` +
+``sleep_between_attempts``) — about 150 seconds on the defaults
+(5 × 1 × 30s). Lower ``contig_frames_before_error`` when the caller has a
+tighter deadline.
+
 .. note::
 
    In remote-gateway URL mode, an empty ``frame_set`` combined with

--- a/docs/guide/detection.rst
+++ b/docs/guide/detection.rst
@@ -435,7 +435,7 @@ Controls frame extraction from ZM events:
      - Number of contiguous frame-fetch failures before aborting
    * - ``max_attempts``
      - ``1``
-     - Number of retry attempts on failure
+     - Number of attempts per frame before it counts as a failure
    * - ``sleep_between_attempts``
      - ``3``
      - Seconds between retry attempts
@@ -471,6 +471,15 @@ Controls frame extraction from ZM events:
        skipping inference on the rest. Applies only to the ``first`` /
        ``first_new`` frame strategies (the ``most*`` strategies always
        process every frame). See :doc:`serve`.
+
+A frame counts as failed when ZM returns an unusable image *or* when the
+fetch fails at the transport level (read timeout, connection drop, or the
+session's own retries exhausted — see ``max_retries`` in
+:doc:`zm_client`). Either way the frame is retried up to ``max_attempts``
+times and then skipped; extraction stops once
+``contig_frames_before_error`` frames fail back to back. Frames already
+extracted are still returned and detection runs on them, so one
+unreachable frame does not abort the event.
 
 .. note::
 

--- a/pyzm/zm/media.py
+++ b/pyzm/zm/media.py
@@ -19,6 +19,8 @@ import time
 from collections.abc import Generator
 from typing import TYPE_CHECKING, Any
 
+import requests
+
 from pyzm.models.config import StreamConfig
 from pyzm.models.zm import Frame
 
@@ -241,7 +243,14 @@ class FrameExtractor:
             self._inter_frame_delay(frames_yielded)
 
     def _fetch_frame_image(self, url: str, cv2: Any, np: Any) -> Any:
-        """Fetch a single frame image from the ZM API, with retries."""
+        """Fetch a single frame image from the ZM API, with retries.
+
+        Returns ``None`` when every attempt fails.  A transport failure
+        (read timeout, connection drop, exhausted session retries) is
+        treated like a bad image rather than being raised, so the caller's
+        ``contig_frames_before_error`` budget decides when to stop the
+        stream and frames already yielded survive.
+        """
         for attempt in range(1, self._cfg.max_attempts + 1):
             try:
                 resp = self._api.request(url)  # type: ignore[union-attr]
@@ -267,8 +276,15 @@ class FrameExtractor:
                 logger.debug(
                     "Bad image on attempt %d/%d", attempt, self._cfg.max_attempts,
                 )
-                if attempt < self._cfg.max_attempts and self._cfg.sleep_between_attempts:
-                    time.sleep(self._cfg.sleep_between_attempts)
+
+            except requests.RequestException as exc:
+                logger.warning(
+                    "Frame fetch failed on attempt %d/%d: %s",
+                    attempt, self._cfg.max_attempts, exc,
+                )
+
+            if attempt < self._cfg.max_attempts and self._cfg.sleep_between_attempts:
+                time.sleep(self._cfg.sleep_between_attempts)
 
         return None
 

--- a/pyzm/zm/media.py
+++ b/pyzm/zm/media.py
@@ -270,17 +270,19 @@ class FrameExtractor:
                 logger.debug("Got JSON instead of image for frame URL")
                 raise ValueError("BAD_IMAGE")
 
+            # Must precede the ValueError clause: requests.JSONDecodeError
+            # subclasses both, and the ValueError branch would re-raise it.
+            except requests.RequestException as exc:
+                logger.warning(
+                    "Frame fetch failed on attempt %d/%d: %s",
+                    attempt, self._cfg.max_attempts, exc,
+                )
+
             except ValueError as exc:
                 if str(exc) != "BAD_IMAGE":
                     raise
                 logger.debug(
                     "Bad image on attempt %d/%d", attempt, self._cfg.max_attempts,
-                )
-
-            except requests.RequestException as exc:
-                logger.warning(
-                    "Frame fetch failed on attempt %d/%d: %s",
-                    attempt, self._cfg.max_attempts, exc,
                 )
 
             if attempt < self._cfg.max_attempts and self._cfg.sleep_between_attempts:

--- a/tests/test_zm/test_media.py
+++ b/tests/test_zm/test_media.py
@@ -1,0 +1,146 @@
+"""Tests for pyzm.zm.media -- FrameExtractor."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from pyzm.models.config import StreamConfig
+from pyzm.zm.media import FrameExtractor
+
+
+# ===================================================================
+# Helpers
+# ===================================================================
+
+def _make_mock_api() -> MagicMock:
+    api = MagicMock()
+    api.portal_url = "https://zm.example.com/zm"
+    return api
+
+
+def _image_response() -> MagicMock:
+    """A requests.Response-alike carrying JPEG bytes."""
+    resp = MagicMock()
+    resp.content = b"\xff\xd8\xff\xe0jpeg-ish"
+    return resp
+
+
+def _mock_cv2() -> MagicMock:
+    """cv2 stub whose imdecode returns an image with a real shape."""
+    cv2 = MagicMock()
+    img = MagicMock()
+    img.shape = (480, 640, 3)
+    cv2.imdecode.return_value = img
+    return cv2
+
+
+# ===================================================================
+# _fetch_frame_image
+# ===================================================================
+
+class TestFetchFrameImage:
+    """A frame fetch must never raise a transport error at the caller."""
+
+    @pytest.mark.parametrize("exc", [
+        requests.ReadTimeout("read timed out"),
+        requests.ConnectionError("connection aborted"),
+        requests.HTTPError("500 server error"),
+    ])
+    def test_transport_error_returns_none(self, exc):
+        api = _make_mock_api()
+        api.request.side_effect = exc
+        extractor = FrameExtractor(
+            api=api,
+            stream_config=StreamConfig(max_attempts=1, sleep_between_attempts=0),
+        )
+
+        assert extractor._fetch_frame_image("url", _mock_cv2(), MagicMock()) is None
+
+    def test_transport_error_retried_up_to_max_attempts(self):
+        api = _make_mock_api()
+        api.request.side_effect = requests.ReadTimeout("read timed out")
+        extractor = FrameExtractor(
+            api=api,
+            stream_config=StreamConfig(max_attempts=3, sleep_between_attempts=0),
+        )
+
+        assert extractor._fetch_frame_image("url", _mock_cv2(), MagicMock()) is None
+        assert api.request.call_count == 3
+
+    def test_recovers_on_later_attempt(self):
+        api = _make_mock_api()
+        api.request.side_effect = [
+            requests.ReadTimeout("read timed out"),
+            _image_response(),
+        ]
+        cv2 = _mock_cv2()
+        extractor = FrameExtractor(
+            api=api,
+            stream_config=StreamConfig(max_attempts=2, sleep_between_attempts=0),
+        )
+
+        img = extractor._fetch_frame_image("url", cv2, MagicMock())
+        assert img is cv2.imdecode.return_value
+        assert api.request.call_count == 2
+
+    def test_relogin_still_propagates(self):
+        """Only BAD_IMAGE is swallowed; RELOGIN must reach the caller."""
+        api = _make_mock_api()
+        api.request.side_effect = ValueError("RELOGIN")
+        extractor = FrameExtractor(
+            api=api,
+            stream_config=StreamConfig(max_attempts=1, sleep_between_attempts=0),
+        )
+
+        with pytest.raises(ValueError, match="RELOGIN"):
+            extractor._fetch_frame_image("url", _mock_cv2(), MagicMock())
+
+
+# ===================================================================
+# _read_zm_event
+# ===================================================================
+
+class TestReadZMEventTransportFailure:
+
+    def _extract(self, api, cfg):
+        extractor = FrameExtractor(api=api, stream_config=cfg)
+        with patch.dict(sys.modules, {"cv2": _mock_cv2(), "numpy": MagicMock()}):
+            return list(extractor.extract_frames("12345"))
+
+    def test_partial_frames_survive_a_persistent_timeout(self):
+        """Frames fetched before the ZM host stalls are still returned."""
+        api = _make_mock_api()
+        api.request.side_effect = [
+            _image_response(),
+            requests.ReadTimeout("read timed out"),
+            requests.ReadTimeout("read timed out"),
+        ]
+        cfg = StreamConfig(
+            frame_set=["1", "2", "3"],
+            contig_frames_before_error=2,
+            max_attempts=1,
+            sleep_between_attempts=0,
+        )
+
+        frames = self._extract(api, cfg)
+
+        assert [f.frame_id for f, _ in frames] == ["1"]
+        assert api.request.call_count == 3
+
+    def test_all_frames_timing_out_yields_nothing_without_raising(self):
+        api = _make_mock_api()
+        api.request.side_effect = requests.ReadTimeout("read timed out")
+        cfg = StreamConfig(
+            frame_set=["1", "2", "3", "4"],
+            contig_frames_before_error=2,
+            max_attempts=1,
+            sleep_between_attempts=0,
+        )
+
+        assert self._extract(api, cfg) == []
+        # Stops at the contiguous-error budget rather than walking the set.
+        assert api.request.call_count == 2

--- a/tests/test_zm/test_media.py
+++ b/tests/test_zm/test_media.py
@@ -99,6 +99,23 @@ class TestFetchFrameImage:
         with pytest.raises(ValueError, match="RELOGIN"):
             extractor._fetch_frame_image("url", _mock_cv2(), MagicMock())
 
+    def test_json_decode_error_returns_none(self):
+        """JSONDecodeError is both a RequestException and a ValueError.
+
+        The RequestException clause has to be matched first, or the
+        ValueError clause sees a message that is not BAD_IMAGE and re-raises.
+        """
+        api = _make_mock_api()
+        api.request.side_effect = requests.exceptions.JSONDecodeError(
+            "Expecting value", "", 0,
+        )
+        extractor = FrameExtractor(
+            api=api,
+            stream_config=StreamConfig(max_attempts=1, sleep_between_attempts=0),
+        )
+
+        assert extractor._fetch_frame_image("url", _mock_cv2(), MagicMock()) is None
+
 
 # ===================================================================
 # _read_zm_event


### PR DESCRIPTION
Fixes #64.

## Problem

`FrameExtractor._fetch_frame_image` only caught `ValueError("BAD_IMAGE")`. A transport failure from `ZMAPI.request()` — read timeout, connection drop, session retries exhausted — escaped the `extract_frames` generator, went through `ZMClient._get_event_frames` and `Detector.detect_event`, and killed the caller. Reported from production (ES hook, camera host stalled mid-event):

```
zmesdetect_m30: FAT [Unrecoverable error:HTTPSConnectionPool(host='...', port=443): Read timed out. (read timeout=30)
  File "zm_detect.py", line 138, in main_handler
    result = detector.detect_event(...)
  File "pyzm/zm/media.py", line 247, in _fetch_frame_image
    resp = self._api.request(url)
requests.exceptions.ReadTimeout
```

Frames already fetched were discarded along with the event, and the two mechanisms built for this case never ran: `_read_zm_event`'s `contig_frames_before_error` budget, and `detect_event`'s empty-frame path (warn, return an empty `DetectionResult`).

## Change

Catch `requests.RequestException` in `_fetch_frame_image` and treat it like a bad image — log a warning, retry per `max_attempts`, then return `None`. The contiguous-error budget decides when to stop the stream. `ValueError("RELOGIN")` still propagates.

The retry-sleep moved out of the `BAD_IMAGE` branch so both failure kinds share it.

## Tests

New `tests/test_zm/test_media.py`, 8 tests. 7 fail on the unpatched code and pass after:

- transport errors (`ReadTimeout` / `ConnectionError` / `HTTPError`) return `None` instead of raising
- retried up to `max_attempts`, and a later attempt can recover
- `RELOGIN` still propagates
- `_read_zm_event`: one good frame followed by persistent timeouts still yields that frame
- all frames timing out yields nothing, raises nothing, and stops at the contiguous-error budget rather than walking the whole set

## Docs

`docs/guide/detection.rst`: state what counts as a failed frame (unusable image *or* transport failure), how `max_attempts` and `contig_frames_before_error` interact, and that extracted frames survive a later failure.

## Verification

- `tests/test_zm tests/test_models tests/test_config*.py tests/test_log.py` — 500 passed.
- Full Tier-1 selection — failure set identical with and without this change; the remainder are missing optional deps (flask, torch, dateparser, shapely) in the test environment, in `test_train`/`test_serve`/`test_ml`.
- zmeventnotificationNg hook suite against this branch on `PYTHONPATH` — 172 passed, including `test_pyzm_contract.py`.

Assisted by Claude on behalf of @pliablepixels.